### PR TITLE
Generate language table from YAML

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,7 +1,8 @@
-from pathlib import Path
 import shutil
 from itertools import chain
+from pathlib import Path
 
+import yaml
 from jinja2 import Environment, PackageLoader, select_autoescape
 
 STATIC_ROOT = Path("./static")
@@ -11,14 +12,21 @@ BUILD_ROOT = Path("./build")
 shutil.rmtree(BUILD_ROOT, ignore_errors=True)
 shutil.copytree(STATIC_ROOT, BUILD_ROOT)
 
+with open(BUILD_ROOT / "languages.yaml") as f:
+    languages = yaml.safe_load(f)
+
 
 env = Environment(loader=PackageLoader("build"), autoescape=select_autoescape())
 
 for template in TEMPLATE_ROOT.glob("**/*.html"):
+    if template.name == "languages.html":
+        kwargs = {"languages": languages.values()}
+    else:
+        kwargs = {}
     template_path = template.relative_to(TEMPLATE_ROOT)
     tgt_dir = BUILD_ROOT / template_path.parent
     tgt_dir.mkdir(parents=True, exist_ok=True)
     tgt_file = tgt_dir / template.name
     template = env.get_template(str(template_path))
     with open(tgt_file, "wt") as f:
-        print(template.render(), file=f)
+        print(template.render(**kwargs), file=f)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Jinja2==3.1.3
 markupsafe==2
+pyyaml==6

--- a/static/languages.yaml
+++ b/static/languages.yaml
@@ -1,0 +1,1736 @@
+ace_Arab:
+  name: Acehnese (Arabic script)
+  glottocode: achi1257
+  iso_639_3: ace
+  iso_15924: Arab
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+ace_Latn:
+  name: Acehnese (Latin script)
+  glottocode: achi1257
+  iso_639_3: ace
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+acm_Arab:
+  name: Mesopotamian Arabic
+  glottocode: meso1252
+  iso_639_3: acm
+  iso_15924: Arab
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+acq_Arab:
+  name: Ta’izzi-Adeni Arabic
+  glottocode: taiz1242
+  iso_639_3: acq
+  iso_15924: Arab
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+aeb_Arab:
+  name: Tunisian Arabic
+  glottocode: tuni1259
+  iso_639_3: aeb
+  iso_15924: Arab
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+afr_Latn:
+  name: Afrikaans
+  glottocode: afri1274
+  iso_639_3: afr
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+ajp_Arab:
+  name: South Levantine Arabic
+  glottocode: sout3123
+  iso_639_3: ajp
+  iso_15924: Arab
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+aka_Latn:
+  name: Akan
+  glottocode: akan1250
+  iso_639_3: aka
+  iso_15924: Latn
+  datasets:
+    flores_dev: warn
+    flores_devtest: warn
+als_Latn:
+  name: Tosk Albanian
+  glottocode: tosk1239
+  iso_639_3: als
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+amh_Ethi:
+  name: Amharic
+  glottocode: amha1245
+  iso_639_3: amh
+  iso_15924: Ethi
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+apc_Arab:
+  name: North Levantine Arabic
+  glottocode: nort3139
+  iso_639_3: apc
+  iso_15924: Arab
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+arb_Arab:
+  name: Modern Standard Arabic
+  glottocode: stan1318
+  iso_639_3: arb
+  iso_15924: Arab
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+arb_Latn:
+  name: Modern Standard Arabic (Romanized)
+  glottocode: stan1318
+  iso_639_3: arb
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+ars_Arab:
+  name: Najdi Arabic
+  glottocode: najd1235
+  iso_639_3: ars
+  iso_15924: Arab
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+ary_Arab:
+  name: Moroccan Arabic
+  glottocode: moro1292
+  iso_639_3: ary
+  iso_15924: Arab
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+arz_Arab:
+  name: Egyptian Arabic
+  glottocode: egyp1253
+  iso_639_3: arz
+  iso_15924: Arab
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+asm_Beng:
+  name: Assamese
+  glottocode: assa1263
+  iso_639_3: asm
+  iso_15924: Beng
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+ast_Latn:
+  name: Asturian
+  glottocode: astu1245
+  iso_639_3: ast
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+awa_Deva:
+  name: Awadhi
+  glottocode: awad1243
+  iso_639_3: awa
+  iso_15924: Deva
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+ayr_Latn:
+  name: Central Aymara
+  glottocode: cent2142
+  iso_639_3: ayr
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+azb_Arab:
+  name: South Azerbaijani
+  glottocode: sout2697
+  iso_639_3: azb
+  iso_15924: Arab
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+azj_Latn:
+  name: North Azerbaijani
+  glottocode: nort2697
+  iso_639_3: azj
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+bak_Cyrl:
+  name: Bashkir
+  glottocode: bash1264
+  iso_639_3: bak
+  iso_15924: Cyrl
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+bam_Latn:
+  name: Bambara
+  glottocode: bamb1269
+  iso_639_3: bam
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+ban_Latn:
+  name: Balinese
+  glottocode: bali1278
+  iso_639_3: ban
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+bel_Cyrl:
+  name: Belarusian
+  glottocode: bela1254
+  iso_639_3: bel
+  iso_15924: Cyrl
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+bem_Latn:
+  name: Bemba
+  glottocode: bemb1257
+  iso_639_3: bem
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+ben_Beng:
+  name: Bengali
+  glottocode: beng1280
+  iso_639_3: ben
+  iso_15924: Beng
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+bho_Deva:
+  name: Bhojpuri
+  glottocode: bhoj1244
+  iso_639_3: bho
+  iso_15924: Deva
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+bjn_Arab:
+  name: Banjar (Arabic script)
+  glottocode: banj1239
+  iso_639_3: bjn
+  iso_15924: Arab
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+bjn_Latn:
+  name: Banjar (Latin script)
+  glottocode: banj1239
+  iso_639_3: bjn
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+bod_Tibt:
+  name: Standard Tibetan
+  glottocode: tibe1272
+  iso_639_3: bod
+  iso_15924: Tibt
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+bos_Latn:
+  name: Bosnian
+  glottocode: bosn1245
+  iso_639_3: bos
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+brx_Deva:
+  name: Bodo
+  glottocode: bodo1269
+  iso_639_3: brx
+  iso_15924: Deva
+  datasets:
+    flores_dev: ok
+bug_Latn:
+  name: Buginese
+  glottocode: bugi1244
+  iso_639_3: bug
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+bul_Cyrl:
+  name: Bulgarian
+  glottocode: bulg1262
+  iso_639_3: bul
+  iso_15924: Cyrl
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+cat_Latn:
+  name: Catalan
+  glottocode: stan1289
+  iso_639_3: cat
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+ceb_Latn:
+  name: Cebuano
+  glottocode: cebu1242
+  iso_639_3: ceb
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+ces_Latn:
+  name: Czech
+  glottocode: czec1258
+  iso_639_3: ces
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+chv_Cyrl:
+  name: Chuvash
+  glottocode: chuv1255
+  iso_639_3: chv
+  iso_15924: Cyrl
+  datasets:
+    flores_dev: ok
+cjk_Latn:
+  name: Chokwe
+  glottocode: chok1245
+  iso_639_3: cjk
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+ckb_Arab:
+  name: Central Kurdish
+  glottocode: cent1972
+  iso_639_3: ckb
+  iso_15924: Arab
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+cmn_Hans:
+  name: Mandarin Chinese (Simplified)
+  glottocode: mand1415
+  iso_639_3: cmn
+  iso_15924: Hans
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+cmn_Hant:
+  name: Mandarin Chinese (Traditional)
+  glottocode: mand1415
+  iso_639_3: cmn
+  iso_15924: Hant
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+crh_Latn:
+  name: Crimean Tatar
+  glottocode: crim1257
+  iso_639_3: crh
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+cym_Latn:
+  name: Welsh
+  glottocode: wels1247
+  iso_639_3: cym
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+dan_Latn:
+  name: Danish
+  glottocode: dani1285
+  iso_639_3: dan
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+deu_Latn:
+  name: German
+  glottocode: stan1295
+  iso_639_3: deu
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+dgo_Deva:
+  name: Dogri
+  glottocode: dogr1250
+  iso_639_3: dgo
+  iso_15924: Deva
+  datasets:
+    flores_dev: ok
+dik_Latn:
+  name: Southwestern Dinka
+  glottocode: sout2832
+  iso_639_3: dik
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+dyu_Latn:
+  name: Dyula
+  glottocode: dyul1238
+  iso_639_3: dyu
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+dzo_Tibt:
+  name: Dzongkha
+  glottocode: dzon1239
+  iso_639_3: dzo
+  iso_15924: Tibt
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+ell_Grek:
+  name: Greek
+  glottocode: mode1248
+  iso_639_3: ell
+  iso_15924: Grek
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+eng_Latn:
+  name: English
+  glottocode: stan1293
+  iso_639_3: eng
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+epo_Latn:
+  name: Esperanto
+  glottocode: espe1235
+  iso_639_3: epo
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+est_Latn:
+  name: Estonian
+  glottocode: kesk1234
+  iso_639_3: ekk
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+eus_Latn:
+  name: Basque
+  glottocode: basq1248
+  iso_639_3: eus
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+ewe_Latn:
+  name: Ewe
+  glottocode: ewee1241
+  iso_639_3: ewe
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+fao_Latn:
+  name: Faroese
+  glottocode: faro1244
+  iso_639_3: fao
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+fij_Latn:
+  name: Fijian
+  glottocode: fiji1243
+  iso_639_3: fij
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+fin_Latn:
+  name: Finnish
+  glottocode: finn1318
+  iso_639_3: fin
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+fon_Latn:
+  name: Fon
+  glottocode: fonn1241
+  iso_639_3: fon
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+fra_Latn:
+  name: French
+  glottocode: stan1290
+  iso_639_3: fra
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+fur_Latn:
+  name: Friulian
+  glottocode: friu1240
+  iso_639_3: fur
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+fuv_Latn:
+  name: Nigerian Fulfulde
+  glottocode: nige1253
+  iso_639_3: fuv
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+gla_Latn:
+  name: Scottish Gaelic
+  glottocode: scot1245
+  iso_639_3: gla
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+gle_Latn:
+  name: Irish
+  glottocode: iris1253
+  iso_639_3: gle
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+glg_Latn:
+  name: Galician
+  glottocode: gali1258
+  iso_639_3: glg
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+gom_Deva:
+  name: Goan Konkani
+  glottocode: goan1235
+  iso_639_3: gom
+  iso_15924: Deva
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+grn_Latn:
+  name: Paraguayan Guaraní
+  glottocode: para1311
+  iso_639_3: gug
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+guj_Gujr:
+  name: Gujarati
+  glottocode: guja1252
+  iso_639_3: guj
+  iso_15924: Gujr
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+hat_Latn:
+  name: Haitian Creole
+  glottocode: hait1244
+  iso_639_3: hat
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+hau_Latn:
+  name: Hausa
+  glottocode: haus1257
+  iso_639_3: hau
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+heb_Hebr:
+  name: Hebrew
+  glottocode: hebr1245
+  iso_639_3: heb
+  iso_15924: Hebr
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+hin_Deva:
+  name: Hindi
+  glottocode: hind1269
+  iso_639_3: hin
+  iso_15924: Deva
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+hne_Deva:
+  name: Chhattisgarhi
+  glottocode: chha1249
+  iso_639_3: hne
+  iso_15924: Deva
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+hrv_Latn:
+  name: Croatian
+  glottocode: croa1245
+  iso_639_3: hrv
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+hun_Latn:
+  name: Hungarian
+  glottocode: hung1274
+  iso_639_3: hun
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+hye_Armn:
+  name: Armenian
+  glottocode: nucl1235
+  iso_639_3: hye
+  iso_15924: Armn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+ibo_Latn:
+  name: Igbo
+  glottocode: nucl1417
+  iso_639_3: ibo
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+ilo_Latn:
+  name: Ilocano
+  glottocode: ilok1237
+  iso_639_3: ilo
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+ind_Latn:
+  name: Indonesian
+  glottocode: indo1316
+  iso_639_3: ind
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+isl_Latn:
+  name: Icelandic
+  glottocode: icel1247
+  iso_639_3: isl
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+ita_Latn:
+  name: Italian
+  glottocode: ital1282
+  iso_639_3: ita
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+jav_Latn:
+  name: Javanese
+  glottocode: java1254
+  iso_639_3: jav
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+jpn_Jpan:
+  name: Japanese
+  glottocode: nucl1643
+  iso_639_3: jpn
+  iso_15924: Jpan
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+kab_Latn:
+  name: Kabyle
+  glottocode: kaby1243
+  iso_639_3: kab
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+kac_Latn:
+  name: Jingpho
+  glottocode: kach1280
+  iso_639_3: kac
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+kam_Latn:
+  name: Kamba
+  glottocode: kamb1297
+  iso_639_3: kam
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+kan_Knda:
+  name: Kannada
+  glottocode: nucl1305
+  iso_639_3: kan
+  iso_15924: Knda
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+kas_Arab:
+  name: Kashmiri (Arabic script)
+  glottocode: kash1277
+  iso_639_3: kas
+  iso_15924: Arab
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+kas_Deva:
+  name: Kashmiri (Devanagari script)
+  glottocode: kash1277
+  iso_639_3: kas
+  iso_15924: Deva
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+kat_Geor:
+  name: Georgian
+  glottocode: nucl1302
+  iso_639_3: kat
+  iso_15924: Geor
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+knc_Arab:
+  name: Central Kanuri (Arabic script)
+  glottocode: cent2050
+  iso_639_3: knc
+  iso_15924: Arab
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+knc_Latn:
+  name: Central Kanuri (Latin script)
+  glottocode: cent2050
+  iso_639_3: knc
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+kaz_Cyrl:
+  name: Kazakh
+  glottocode: kaza1248
+  iso_639_3: kaz
+  iso_15924: Cyrl
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+kbp_Latn:
+  name: Kabiyè
+  glottocode: kabi1261
+  iso_639_3: kbp
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+kea_Latn:
+  name: Kabuverdianu
+  glottocode: kabu1256
+  iso_639_3: kea
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+khm_Khmr:
+  name: Khmer
+  glottocode: cent1989
+  iso_639_3: khm
+  iso_15924: Khmr
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+kik_Latn:
+  name: Kikuyu
+  glottocode: kiku1240
+  iso_639_3: kik
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+kin_Latn:
+  name: Kinyarwanda
+  glottocode: kiny1244
+  iso_639_3: kin
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+kir_Cyrl:
+  name: Kyrgyz
+  glottocode: kirg1245
+  iso_639_3: kir
+  iso_15924: Cyrl
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+kmb_Latn:
+  name: Kimbundu
+  glottocode: kimb1241
+  iso_639_3: kmb
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+kmr_Latn:
+  name: Northern Kurdish
+  glottocode: nort2641
+  iso_639_3: kmr
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+kon_Latn:
+  name: Kituba (DRC)
+  glottocode: kitu1246
+  iso_639_3: ktu
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+kor_Hang:
+  name: Korean
+  glottocode: kore1280
+  iso_639_3: kor
+  iso_15924: Hang
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+lao_Laoo:
+  name: Lao
+  glottocode: laoo1244
+  iso_639_3: lao
+  iso_15924: Laoo
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+lij_Latn:
+  name: Genoese Ligurian
+  glottocode: geno1240
+  iso_639_3: lij
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+fil_Latn:
+  name: Filipino
+  glottocode: fili1244
+  iso_639_3: fil
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+lim_Latn:
+  name: Limburgish
+  glottocode: limb1263
+  iso_639_3: lim
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+lin_Latn:
+  name: Lingala
+  glottocode: ling1263
+  iso_639_3: lin
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+lit_Latn:
+  name: Lithuanian
+  glottocode: lith1251
+  iso_639_3: lit
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+lmo_Latn:
+  name: Lombard
+  glottocode: lomb1257
+  iso_639_3: lmo
+  iso_15924: Latn
+  datasets:
+    flores_dev: warn
+    flores_devtest: warn
+    seed: warn
+  issues:
+  - https://github.com/openlanguagedata/flores/issues/5
+ltg_Latn:
+  name: Latgalian
+  glottocode: east2282
+  iso_639_3: ltg
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+ltz_Latn:
+  name: Luxembourgish
+  glottocode: luxe1241
+  iso_639_3: ltz
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+lua_Latn:
+  name: Luba-Kasai
+  glottocode: luba1249
+  iso_639_3: lua
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+lug_Latn:
+  name: Ganda
+  glottocode: gand1255
+  iso_639_3: lug
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+luo_Latn:
+  name: Luo
+  glottocode: luok1236
+  iso_639_3: luo
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+lus_Latn:
+  name: Mizo
+  glottocode: lush1249
+  iso_639_3: lus
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+lvs_Latn:
+  name: Standard Latvian
+  glottocode: stan1325
+  iso_639_3: lvs
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+mag_Deva:
+  name: Magahi
+  glottocode: maga1260
+  iso_639_3: mag
+  iso_15924: Deva
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+mai_Deva:
+  name: Maithili
+  glottocode: mait1250
+  iso_639_3: mai
+  iso_15924: Deva
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+mal_Mlym:
+  name: Malayalam
+  glottocode: mala1464
+  iso_639_3: mal
+  iso_15924: Mlym
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+mar_Deva:
+  name: Marathi
+  glottocode: mara1378
+  iso_639_3: mar
+  iso_15924: Deva
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+mhr_Cyrl:
+  name: Meadow Mari
+  glottocode: east2328
+  iso_639_3: mhr
+  iso_15924: Cyrl
+  datasets:
+    flores_dev: ok
+min_Arab:
+  name: Minangkabau (Arabic script)
+  glottocode: mina1268
+  iso_639_3: min
+  iso_15924: Arab
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+min_Latn:
+  name: Minangkabau (Latin script)
+  glottocode: mina1268
+  iso_639_3: min
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+mkd_Cyrl:
+  name: Macedonian
+  glottocode: mace1250
+  iso_639_3: mkd
+  iso_15924: Cyrl
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+plt_Latn:
+  name: Plateau Malagasy
+  glottocode: plat1254
+  iso_639_3: plt
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+mlt_Latn:
+  name: Maltese
+  glottocode: malt1254
+  iso_639_3: mlt
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+mni_Beng:
+  name: Meitei (Bengali script)
+  glottocode: mani1292
+  iso_639_3: mni
+  iso_15924: Beng
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+mni_Mtei:
+  name: Meitei (Meitei script)
+  glottocode: mani1292
+  iso_639_3: mni
+  iso_15924: Mtei
+  datasets:
+    flores_dev: ok
+khk_Cyrl:
+  name: Halh Mongolian
+  glottocode: halh1238
+  iso_639_3: khk
+  iso_15924: Cyrl
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+mos_Latn:
+  name: Mossi
+  glottocode: moss1236
+  iso_639_3: mos
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+mri_Latn:
+  name: Maori
+  glottocode: maor1246
+  iso_639_3: mri
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+mya_Mymr:
+  name: Burmese
+  glottocode: nucl1310
+  iso_639_3: mya
+  iso_15924: Mymr
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+nld_Latn:
+  name: Dutch
+  glottocode: dutc1256
+  iso_639_3: nld
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+nno_Latn:
+  name: Norwegian Nynorsk
+  glottocode: norw1262
+  iso_639_3: nno
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+nob_Latn:
+  name: Norwegian Bokmål
+  glottocode: norw1259
+  iso_639_3: nob
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+npi_Deva:
+  name: Nepali
+  glottocode: nepa1254
+  iso_639_3: npi
+  iso_15924: Deva
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+nqo_Nkoo:
+  name: Nko
+  glottocode: nkoa1234
+  iso_639_3: nqo
+  iso_15924: Nkoo
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+nso_Latn:
+  name: Northern Sotho
+  glottocode: pedi1238
+  iso_639_3: nso
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+nus_Latn:
+  name: Nuer
+  glottocode: nuer1246
+  iso_639_3: nus
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+nya_Latn:
+  name: Nyanja
+  glottocode: nyan1308
+  iso_639_3: nya
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+oci_Latn:
+  name: Occitan
+  glottocode: occi1239
+  iso_639_3: oci
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+gaz_Latn:
+  name: West Central Oromo
+  glottocode: west2721
+  iso_639_3: gaz
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+ory_Orya:
+  name: Odia
+  glottocode: oriy1255
+  iso_639_3: ory
+  iso_15924: Orya
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+pag_Latn:
+  name: Pangasinan
+  glottocode: pang1290
+  iso_639_3: pag
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+pan_Guru:
+  name: Eastern Panjabi
+  glottocode: panj1256
+  iso_639_3: pan
+  iso_15924: Guru
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+pap_Latn:
+  name: Papiamento
+  glottocode: papi1253
+  iso_639_3: pap
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+pes_Arab:
+  name: Western Persian
+  glottocode: west2369
+  iso_639_3: pes
+  iso_15924: Arab
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+pol_Latn:
+  name: Polish
+  glottocode: poli1260
+  iso_639_3: pol
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+por_Latn:
+  name: Portuguese
+  glottocode: port1283
+  iso_639_3: por
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+prs_Arab:
+  name: Dari
+  glottocode: dari1249
+  iso_639_3: prs
+  iso_15924: Arab
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+pbt_Arab:
+  name: Southern Pashto
+  glottocode: sout2649
+  iso_639_3: pbt
+  iso_15924: Arab
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+quy_Latn:
+  name: Ayacucho Quechua
+  glottocode: ayac1239
+  iso_639_3: quy
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+ron_Latn:
+  name: Romanian
+  glottocode: roma1327
+  iso_639_3: ron
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+run_Latn:
+  name: Rundi
+  glottocode: rund1242
+  iso_639_3: run
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+rus_Cyrl:
+  name: Russian
+  glottocode: russ1263
+  iso_639_3: rus
+  iso_15924: Cyrl
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+sag_Latn:
+  name: Sango
+  glottocode: sang1328
+  iso_639_3: sag
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+san_Deva:
+  name: Sanskrit
+  glottocode: sans1269
+  iso_639_3: san
+  iso_15924: Deva
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+sat_Olck:
+  name: Santali
+  glottocode: sant1410
+  iso_639_3: sat
+  iso_15924: Olck
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+scn_Latn:
+  name: Sicilian
+  glottocode: sici1248
+  iso_639_3: scn
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+shn_Mymr:
+  name: Shan
+  glottocode: shan1277
+  iso_639_3: shn
+  iso_15924: Mymr
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+sin_Sinh:
+  name: Sinhala
+  glottocode: sinh1246
+  iso_639_3: sin
+  iso_15924: Sinh
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+slk_Latn:
+  name: Slovak
+  glottocode: slov1269
+  iso_639_3: slk
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+slv_Latn:
+  name: Slovenian
+  glottocode: slov1268
+  iso_639_3: slv
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+smo_Latn:
+  name: Samoan
+  glottocode: samo1305
+  iso_639_3: smo
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+sna_Latn:
+  name: Shona
+  glottocode: shon1251
+  iso_639_3: sna
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+snd_Arab:
+  name: Sindhi (Arabic script)
+  glottocode: sind1272
+  iso_639_3: snd
+  iso_15924: Arab
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+snd_Deva:
+  name: Sindhi (Devanagari script)
+  glottocode: sind1272
+  iso_639_3: snd
+  iso_15924: Deva
+  datasets:
+    flores_dev: ok
+som_Latn:
+  name: Somali
+  glottocode: soma1255
+  iso_639_3: som
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+sot_Latn:
+  name: Southern Sotho
+  glottocode: sout2807
+  iso_639_3: sot
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+spa_Latn:
+  name: Spanish
+  glottocode: stan1288
+  iso_639_3: spa
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+srd_Latn:
+  name: Sardinian
+  glottocode: sard1257
+  iso_639_3: srd
+  iso_15924: Latn
+  datasets:
+    flores_dev: warn
+    flores_devtest: warn
+    seed: warn
+  issues:
+  - https://github.com/openlanguagedata/flores/issues/6
+srp_Cyrl:
+  name: Serbian
+  glottocode: serb1264
+  iso_639_3: srp
+  iso_15924: Cyrl
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+ssw_Latn:
+  name: Swati
+  glottocode: swat1243
+  iso_639_3: ssw
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+sun_Latn:
+  name: Sundanese
+  glottocode: sund1252
+  iso_639_3: sun
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+swe_Latn:
+  name: Swedish
+  glottocode: swed1254
+  iso_639_3: swe
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+swh_Latn:
+  name: Swahili
+  glottocode: swah1253
+  iso_639_3: swh
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+szl_Latn:
+  name: Silesian
+  glottocode: sile1253
+  iso_639_3: szl
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+tam_Taml:
+  name: Tamil
+  glottocode: tami1289
+  iso_639_3: tam
+  iso_15924: Taml
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+tat_Cyrl:
+  name: Tatar
+  glottocode: tata1255
+  iso_639_3: tat
+  iso_15924: Cyrl
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+tel_Telu:
+  name: Telugu
+  glottocode: telu1262
+  iso_639_3: tel
+  iso_15924: Telu
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+tgk_Cyrl:
+  name: Tajik
+  glottocode: taji1245
+  iso_639_3: tgk
+  iso_15924: Cyrl
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+tha_Thai:
+  name: Thai
+  glottocode: thai1261
+  iso_639_3: tha
+  iso_15924: Thai
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+tir_Ethi:
+  name: Tigrinya
+  glottocode: tigr1271
+  iso_639_3: tir
+  iso_15924: Ethi
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+taq_Latn:
+  name: Tamasheq (Latin script)
+  glottocode: tama1365
+  iso_639_3: taq
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+taq_Tfng:
+  name: Tamasheq (Tifinagh script)
+  glottocode: tama1365
+  iso_639_3: taq
+  iso_15924: Tfng
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+tpi_Latn:
+  name: Tok Pisin
+  glottocode: tokp1240
+  iso_639_3: tpi
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+tsn_Latn:
+  name: Tswana
+  glottocode: tswa1253
+  iso_639_3: tsn
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+tso_Latn:
+  name: Tsonga
+  glottocode: tson1249
+  iso_639_3: tso
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+tuk_Latn:
+  name: Turkmen
+  glottocode: turk1304
+  iso_639_3: tuk
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+tum_Latn:
+  name: Tumbuka
+  glottocode: tumb1250
+  iso_639_3: tum
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+tur_Latn:
+  name: Turkish
+  glottocode: nucl1301
+  iso_639_3: tur
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+twi_Latn:
+  name: Twi
+  glottocode: twii1234
+  iso_639_3: twi
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+uig_Arab:
+  name: Uyghur
+  glottocode: uigh1240
+  iso_639_3: uig
+  iso_15924: Arab
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+ukr_Cyrl:
+  name: Ukrainian
+  glottocode: ukra1253
+  iso_639_3: ukr
+  iso_15924: Cyrl
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+umb_Latn:
+  name: Umbundu
+  glottocode: umbu1257
+  iso_639_3: umb
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+urd_Arab:
+  name: Urdu
+  glottocode: urdu1245
+  iso_639_3: urd
+  iso_15924: Arab
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+uzn_Latn:
+  name: Northern Uzbek
+  glottocode: nort2690
+  iso_639_3: uzn
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+vec_Latn:
+  name: Venetian
+  glottocode: vene1258
+  iso_639_3: vec
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+vie_Latn:
+  name: Vietnamese
+  glottocode: viet1252
+  iso_639_3: vie
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+war_Latn:
+  name: Waray
+  glottocode: wara1300
+  iso_639_3: war
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+wol_Latn:
+  name: Wolof
+  glottocode: nucl1347
+  iso_639_3: wol
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+xho_Latn:
+  name: Xhosa
+  glottocode: xhos1239
+  iso_639_3: xho
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+ydd_Hebr:
+  name: Eastern Yiddish
+  glottocode: east2295
+  iso_639_3: ydd
+  iso_15924: Hebr
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+yor_Latn:
+  name: Yoruba
+  glottocode: yoru1245
+  iso_639_3: yor
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+yue_Hant:
+  name: Hong Kong Cantonese
+  glottocode: xian1255
+  iso_639_3: yue
+  iso_15924: Hant
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+zgh_Tfng:
+  name: Standard Moroccan Tamazight
+  glottocode: stan1324
+  iso_639_3: zgh
+  iso_15924: Tfng
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+    seed: ok
+zsm_Latn:
+  name: Standard Malay
+  glottocode: stan1306
+  iso_639_3: zsm
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+zul_Latn:
+  name: Zulu
+  glottocode: zulu1248
+  iso_639_3: zul
+  iso_15924: Latn
+  datasets:
+    flores_dev: ok
+    flores_devtest: ok
+

--- a/templates/languages.html
+++ b/templates/languages.html
@@ -16,220 +16,35 @@
 
 <table class="c l3 l4">
     <thead>
-        <tr><th>Code</th><th>Script</th><th>Language</th><th>Variety</th><th><a href="https://github.com/openlanguagedata/flores">FLORES+</a></th><th><a href="https://github.com/openlanguagedata/seed">Seed</a></th></tr>
+        <tr><th>Code</th><th>Script</th><th>Glottocode</th><th>Language</th><th><a href="https://github.com/openlanguagedata/flores">FLORES+</a></th><th><a href="https://github.com/openlanguagedata/seed">Seed</a></th></tr>
     </thead>
     <tbody>
-        <tr><td><code>ace</code></td><td><code>Arab</code></td><td>Acehnese</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>ace</code></td><td><code>Latn</code></td><td>Acehnese</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>acm</code></td><td><code>Arab</code></td><td>Mesopotamian Arabic</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>acq</code></td><td><code>Arab</code></td><td>Ta’izzi-Adeni Arabic</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>aeb</code></td><td><code>Arab</code></td><td>Tunisian Arabic</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>afr</code></td><td><code>Latn</code></td><td>Afrikaans</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>ajp</code></td><td><code>Arab</code></td><td>South Levantine Arabic</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>aka</code></td><td><code>Latn</code></td><td>Akan</td><td></td><td><img src="/warn.png" class="i" alt="issues reported" title="issues reported"></td><td></td></tr>
-        <tr><td><code>als</code></td><td><code>Latn</code></td><td>Tosk Albanian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>amh</code></td><td><code>Ethi</code></td><td>Amharic</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>apc</code></td><td><code>Arab</code></td><td>North Levantine Arabic</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>arb</code></td><td><code>Arab</code></td><td>Modern Standard Arabic</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>arb</code></td><td><code>Latn</code></td><td>Modern Standard Arabic</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>ars</code></td><td><code>Arab</code></td><td>Najdi Arabic</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>ary</code></td><td><code>Arab</code></td><td>Moroccan Arabic</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>arz</code></td><td><code>Arab</code></td><td>Egyptian Arabic</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>asm</code></td><td><code>Beng</code></td><td>Assamese</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>ast</code></td><td><code>Latn</code></td><td>Asturian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>awa</code></td><td><code>Deva</code></td><td>Awadhi</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>ayr</code></td><td><code>Latn</code></td><td>Central Aymara</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>azb</code></td><td><code>Arab</code></td><td>South Azerbaijani</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>azj</code></td><td><code>Latn</code></td><td>North Azerbaijani</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>bak</code></td><td><code>Cyrl</code></td><td>Bashkir</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>bam</code></td><td><code>Latn</code></td><td>Bambara</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>ban</code></td><td><code>Latn</code></td><td>Balinese</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>bel</code></td><td><code>Cyrl</code></td><td>Belarusian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>bem</code></td><td><code>Latn</code></td><td>Bemba</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>ben</code></td><td><code>Beng</code></td><td>Bengali</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>bho</code></td><td><code>Deva</code></td><td>Bhojpuri</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>bjn</code></td><td><code>Arab</code></td><td>Banjar</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>bjn</code></td><td><code>Latn</code></td><td>Banjar</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>bod</code></td><td><code>Tibt</code></td><td>Standard Tibetan</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>bos</code></td><td><code>Latn</code></td><td>Bosnian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>brx</code></td><td><code>Deva</code></td><td>Bodo</td><td></td><td><img src="/partial.png" class="i" alt="partially available" title="partially available"></td><td></td></tr>
-        <tr><td><code>bug</code></td><td><code>Latn</code></td><td>Buginese</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>bul</code></td><td><code>Cyrl</code></td><td>Bulgarian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>cat</code></td><td><code>Latn</code></td><td>Catalan</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>ceb</code></td><td><code>Latn</code></td><td>Cebuano</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>ces</code></td><td><code>Latn</code></td><td>Czech</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>chv</code></td><td><code>Cyrl</code></td><td>Chuvash</td><td></td><td><img src="/partial.png" class="i" alt="partially available" title="partially available"></td><td></td></tr>
-        <tr><td><code>cjk</code></td><td><code>Latn</code></td><td>Chokwe</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>cmn</code></td><td><code>Hans</code></td><td>Mandarin Chinese</td><td>Standard Beijing</td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>cmn</code></td><td><code>Hant</code></td><td>Mandarin Chinese</td><td>Taiwanese</td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>ckb</code></td><td><code>Arab</code></td><td>Central Kurdish</td><td></td><td><img src="/warn.png" class="i" alt="issues reported" title="issues reported"></td><td></td></tr>
-        <tr><td><code>crh</code></td><td><code>Latn</code></td><td>Crimean Tatar</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>cym</code></td><td><code>Latn</code></td><td>Welsh</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>dan</code></td><td><code>Latn</code></td><td>Danish</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>deu</code></td><td><code>Latn</code></td><td>German</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>dgo</code></td><td><code>Deva</code></td><td>Dogri</td><td></td><td><img src="/partial.png" class="i" alt="partially available" title="partially available"></td><td></td></tr>
-        <tr><td><code>dik</code></td><td><code>Latn</code></td><td>Southwestern Dinka</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>dyu</code></td><td><code>Latn</code></td><td>Dyula</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>dzo</code></td><td><code>Tibt</code></td><td>Dzongkha</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>ell</code></td><td><code>Grek</code></td><td>Greek</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>eng</code></td><td><code>Latn</code></td><td>English</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>epo</code></td><td><code>Latn</code></td><td>Esperanto</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>est</code></td><td><code>Latn</code></td><td>Estonian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>eus</code></td><td><code>Latn</code></td><td>Basque</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>ewe</code></td><td><code>Latn</code></td><td>Ewe</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>fao</code></td><td><code>Latn</code></td><td>Faroese</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>fij</code></td><td><code>Latn</code></td><td>Fijian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>fil</code></td><td><code>Latn</code></td><td>Filipino</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>fin</code></td><td><code>Latn</code></td><td>Finnish</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>fon</code></td><td><code>Latn</code></td><td>Fon</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>fra</code></td><td><code>Latn</code></td><td>French</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>fur</code></td><td><code>Latn</code></td><td>Friulian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>fuv</code></td><td><code>Latn</code></td><td>Nigerian Fulfulde</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>gla</code></td><td><code>Latn</code></td><td>Scottish Gaelic</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>gle</code></td><td><code>Latn</code></td><td>Irish</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>glg</code></td><td><code>Latn</code></td><td>Galician</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>gom</code></td><td><code>Deva</code></td><td>Goan Konkani</td><td></td><td><img src="/partial.png" class="i" alt="partially available" title="partially available"></td><td></td></tr>
-        <tr><td><code>grn</code></td><td><code>Latn</code></td><td>Guarani</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>guj</code></td><td><code>Gujr</code></td><td>Gujarati</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>hat</code></td><td><code>Latn</code></td><td>Haitian Creole</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>hau</code></td><td><code>Latn</code></td><td>Hausa</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>heb</code></td><td><code>Hebr</code></td><td>Hebrew</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>hin</code></td><td><code>Deva</code></td><td>Hindi</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>hne</code></td><td><code>Deva</code></td><td>Chhattisgarhi</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>hrv</code></td><td><code>Latn</code></td><td>Croatian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>hun</code></td><td><code>Latn</code></td><td>Hungarian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>hye</code></td><td><code>Armn</code></td><td>Armenian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>ibo</code></td><td><code>Latn</code></td><td>Igbo</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>ilo</code></td><td><code>Latn</code></td><td>Ilocano</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>ind</code></td><td><code>Latn</code></td><td>Indonesian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>isl</code></td><td><code>Latn</code></td><td>Icelandic</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>ita</code></td><td><code>Latn</code></td><td>Italian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>jav</code></td><td><code>Latn</code></td><td>Javanese</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>jpn</code></td><td><code>Jpan</code></td><td>Japanese</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>kab</code></td><td><code>Latn</code></td><td>Kabyle</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>kac</code></td><td><code>Latn</code></td><td>Jingpho</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>kam</code></td><td><code>Latn</code></td><td>Kamba</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>kan</code></td><td><code>Knda</code></td><td>Kannada</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>kas</code></td><td><code>Arab</code></td><td>Kashmiri</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>kas</code></td><td><code>Deva</code></td><td>Kashmiri</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>kat</code></td><td><code>Geor</code></td><td>Georgian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>knc</code></td><td><code>Arab</code></td><td>Central Kanuri</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>knc</code></td><td><code>Latn</code></td><td>Central Kanuri</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>kaz</code></td><td><code>Cyrl</code></td><td>Kazakh</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>kbp</code></td><td><code>Latn</code></td><td>Kabiyè</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>kea</code></td><td><code>Latn</code></td><td>Kabuverdianu</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>khm</code></td><td><code>Khmr</code></td><td>Khmer</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>kik</code></td><td><code>Latn</code></td><td>Kikuyu</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>kin</code></td><td><code>Latn</code></td><td>Kinyarwanda</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>kir</code></td><td><code>Cyrl</code></td><td>Kyrgyz</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>kmb</code></td><td><code>Latn</code></td><td>Kimbundu</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>kmr</code></td><td><code>Latn</code></td><td>Northern Kurdish</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>kon</code></td><td><code>Latn</code></td><td>Kikongo</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>kor</code></td><td><code>Hang</code></td><td>Korean</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>lao</code></td><td><code>Laoo</code></td><td>Lao</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>lij</code></td><td><code>Latn</code></td><td>Ligurian</td><td>Genoese</td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>lim</code></td><td><code>Latn</code></td><td>Limburgish</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>lin</code></td><td><code>Latn</code></td><td>Lingala</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>lit</code></td><td><code>Latn</code></td><td>Lithuanian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>lmo</code></td><td><code>Latn</code></td><td>Lombard</td><td></td><td><img src="/warn.png" class="i" alt="issues reported" title="issues reported"></td><td><img src="/warn.png" class="i" alt="issues reported" title="issues reported"></td></tr>
-        <tr><td><code>ltg</code></td><td><code>Latn</code></td><td>Latgalian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>ltz</code></td><td><code>Latn</code></td><td>Luxembourgish</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>lua</code></td><td><code>Latn</code></td><td>Luba-Kasai</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>lug</code></td><td><code>Latn</code></td><td>Ganda</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>luo</code></td><td><code>Latn</code></td><td>Luo</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>lus</code></td><td><code>Latn</code></td><td>Mizo</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>lvs</code></td><td><code>Latn</code></td><td>Standard Latvian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>mag</code></td><td><code>Deva</code></td><td>Magahi</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>mai</code></td><td><code>Deva</code></td><td>Maithili</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>mal</code></td><td><code>Mlym</code></td><td>Malayalam</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>mar</code></td><td><code>Deva</code></td><td>Marathi</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>mhr</code></td><td><code>Cyrl</code></td><td>Meadow Mari</td><td></td><td><img src="/partial.png" class="i" alt="partially available" title="partially available"></td><td></td></tr>
-        <tr><td><code>min</code></td><td><code>Arab</code></td><td>Minangkabau</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>min</code></td><td><code>Latn</code></td><td>Minangkabau</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>mkd</code></td><td><code>Cyrl</code></td><td>Macedonian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>plt</code></td><td><code>Latn</code></td><td>Plateau Malagasy</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>mlt</code></td><td><code>Latn</code></td><td>Maltese</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>mni</code></td><td><code>Beng</code></td><td>Meitei</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>mni</code></td><td><code>Mtei</code></td><td>Meitei</td><td></td><td><img src="/partial.png" class="i" alt="partially available" title="partially available"></td><td></td></tr>
-        <tr><td><code>khk</code></td><td><code>Cyrl</code></td><td>Halh Mongolian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>mos</code></td><td><code>Latn</code></td><td>Mossi</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>mri</code></td><td><code>Latn</code></td><td>Maori</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>mya</code></td><td><code>Mymr</code></td><td>Burmese</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>nld</code></td><td><code>Latn</code></td><td>Dutch</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>nno</code></td><td><code>Latn</code></td><td>Norwegian Nynorsk</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>nob</code></td><td><code>Latn</code></td><td>Norwegian Bokmål</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>npi</code></td><td><code>Deva</code></td><td>Nepali</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>nqo</code></td><td><code>Nkoo</code></td><td>Nko</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>nso</code></td><td><code>Latn</code></td><td>Northern Sotho</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>nus</code></td><td><code>Latn</code></td><td>Nuer</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>nya</code></td><td><code>Latn</code></td><td>Nyanja</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>oci</code></td><td><code>Latn</code></td><td>Occitan</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>gaz</code></td><td><code>Latn</code></td><td>West Central Oromo</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>ory</code></td><td><code>Orya</code></td><td>Odia</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>pag</code></td><td><code>Latn</code></td><td>Pangasinan</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>pan</code></td><td><code>Guru</code></td><td>Eastern Panjabi</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>pap</code></td><td><code>Latn</code></td><td>Papiamento</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>pes</code></td><td><code>Arab</code></td><td>Western Persian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>pol</code></td><td><code>Latn</code></td><td>Polish</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>por</code></td><td><code>Latn</code></td><td>Portuguese</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>prs</code></td><td><code>Arab</code></td><td>Dari</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>pbt</code></td><td><code>Arab</code></td><td>Southern Pashto</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>quy</code></td><td><code>Latn</code></td><td>Ayacucho Quechua</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>ron</code></td><td><code>Latn</code></td><td>Romanian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>run</code></td><td><code>Latn</code></td><td>Rundi</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>rus</code></td><td><code>Cyrl</code></td><td>Russian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>sag</code></td><td><code>Latn</code></td><td>Sango</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>san</code></td><td><code>Deva</code></td><td>Sanskrit</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>sat</code></td><td><code>Olck</code></td><td>Santali</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>scn</code></td><td><code>Latn</code></td><td>Sicilian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>shn</code></td><td><code>Mymr</code></td><td>Shan</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>sin</code></td><td><code>Sinh</code></td><td>Sinhala</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>slk</code></td><td><code>Latn</code></td><td>Slovak</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>slv</code></td><td><code>Latn</code></td><td>Slovenian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>smo</code></td><td><code>Latn</code></td><td>Samoan</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>sna</code></td><td><code>Latn</code></td><td>Shona</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>snd</code></td><td><code>Arab</code></td><td>Sindhi</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>som</code></td><td><code>Latn</code></td><td>Somali</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>sot</code></td><td><code>Latn</code></td><td>Southern Sotho</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>spa</code></td><td><code>Latn</code></td><td>Spanish</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>srd</code></td><td><code>Latn</code></td><td>Sardinian</td><td></td><td><img src="/warn.png" class="i" alt="issues reported" title="issues reported"></td><td><img src="/warn.png" class="i" alt="issues reported" title="issues reported"></td></tr>
-        <tr><td><code>srp</code></td><td><code>Cyrl</code></td><td>Serbian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>ssw</code></td><td><code>Latn</code></td><td>Swati</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>sun</code></td><td><code>Latn</code></td><td>Sundanese</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>swe</code></td><td><code>Latn</code></td><td>Swedish</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>swh</code></td><td><code>Latn</code></td><td>Swahili</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>szl</code></td><td><code>Latn</code></td><td>Silesian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>tam</code></td><td><code>Taml</code></td><td>Tamil</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>tat</code></td><td><code>Cyrl</code></td><td>Tatar</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>tel</code></td><td><code>Telu</code></td><td>Telugu</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>tgk</code></td><td><code>Cyrl</code></td><td>Tajik</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>tha</code></td><td><code>Thai</code></td><td>Thai</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>tir</code></td><td><code>Ethi</code></td><td>Tigrinya</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>taq</code></td><td><code>Latn</code></td><td>Tamasheq</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>taq</code></td><td><code>Tfng</code></td><td>Tamasheq</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>tpi</code></td><td><code>Latn</code></td><td>Tok Pisin</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>tsn</code></td><td><code>Latn</code></td><td>Tswana</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>tso</code></td><td><code>Latn</code></td><td>Tsonga</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>tuk</code></td><td><code>Latn</code></td><td>Turkmen</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>tum</code></td><td><code>Latn</code></td><td>Tumbuka</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>tur</code></td><td><code>Latn</code></td><td>Turkish</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>twi</code></td><td><code>Latn</code></td><td>Twi</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>uig</code></td><td><code>Arab</code></td><td>Uyghur</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>ukr</code></td><td><code>Cyrl</code></td><td>Ukrainian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>umb</code></td><td><code>Latn</code></td><td>Umbundu</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>urd</code></td><td><code>Arab</code></td><td>Urdu</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>uzn</code></td><td><code>Latn</code></td><td>Northern Uzbek</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>vec</code></td><td><code>Latn</code></td><td>Venetian</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>vie</code></td><td><code>Latn</code></td><td>Vietnamese</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>war</code></td><td><code>Latn</code></td><td>Waray</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>wol</code></td><td><code>Latn</code></td><td>Wolof</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>xho</code></td><td><code>Latn</code></td><td>Xhosa</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>ydd</code></td><td><code>Hebr</code></td><td>Eastern Yiddish</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>yor</code></td><td><code>Latn</code></td><td>Yoruba</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>yue</code></td><td><code>Hant</code></td><td>Yue Chinese</td><td>Hong Kong Cantonese</td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>zgh</code></td><td><code>Tfng</code></td><td>Standard Moroccan Tamazight</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td><img src="/ok.png" class="i" alt="available" title="available"></td></tr>
-        <tr><td><code>zsm</code></td><td><code>Latn</code></td><td>Standard Malay</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
-        <tr><td><code>zul</code></td><td><code>Latn</code></td><td>Zulu</td><td></td><td><img src="/ok.png" class="i" alt="available" title="available"></td><td></td></tr>
+        {% for lang in languages -%}
+        <tr>
+            <td><code>{{ lang.iso_639_3 }}</code></td>
+            <td><code>{{ lang.iso_15924 }}</code></td>
+            <td>{% if lang.glottocode %}<code>{{ lang.glottocode }}</code>{% endif %}</td>
+            <td>{{ lang.name }}</td>
+            <td>
+                {%- if lang.datasets.flores_dev == "ok" and lang.datasets.flores_devtest == "ok" -%}
+                <img src="/ok.png" class="i" alt="available" title="available">
+                {%- elif lang.datasets.flores_dev == "warn" or lang.datasets.flores_devtest == "warn" -%}
+                <img src="/warn.png" class="i" alt="issues reported" title="issues reported">
+                {%- elif lang.datasets.flores_dev in ["ok", "partial"] or lang.datasets.flores_devtest in ["ok", "partial"] -%}
+                <img src="/partial.png" class="i" alt="partially available" title="partially available">
+                {%- endif -%}
+            </td>
+            <td>
+                {%- if lang.datasets.seed == "ok" -%}
+                <img src="/ok.png" class="i" alt="available" title="available">
+                {%- elif lang.datasets.seed == "warn" -%}
+                <img src="/warn.png" class="i" alt="issues reported" title="issues reported">
+                {%- elif lang.datasets.seed == "partial" -%}
+                <img src="/partial.png" class="i" alt="partially available" title="partially available">
+                {%- endif -%}
+            </td>
+        </tr>
+        {%- endfor %}
     </tbody>
 </table>
 


### PR DESCRIPTION
This creates a `languages.yaml` file which aims to be a single source of truth for language and resource information. It contains some additional information from what we had before:
* Glottocodes.
* List of relevant open issues in repositories.
* Detailed information about which datasets exist and what their status is (ok/partial/warn).

The language table on the website is now built from `languages.yaml`.

In the future, we will be able to generate the markdown table in the FLORES+ and Seed repos automatically from this YAML file, via a GitHub Action. I will do this as a separate PR.
