### PR TITLE
Update language info and table

### DIFF
--- a/build.py
+++ b/build.py
@@ -12,9 +12,9 @@ BUILD_ROOT = Path("./build")
 shutil.rmtree(BUILD_ROOT, ignore_errors=True)
 shutil.copytree(STATIC_ROOT, BUILD_ROOT)
 
-with open(BUILD_ROOT / "languages.yaml") as f:
+with open("languages.yaml") as f:
     languages = yaml.safe_load(f)
-
+shutil.copy("languages.yaml", BUILD_ROOT)
 
 env = Environment(loader=PackageLoader("build"), autoescape=select_autoescape())
 

--- a/languages.yaml
+++ b/languages.yaml
@@ -48,7 +48,7 @@ afr_Latn:
   datasets:
     flores_dev: ok
     flores_devtest: ok
-ajp_Arab:
+apc_Arab_sout3123:
   name: South Levantine Arabic
   glottocode: sout3123
   iso_639_3: ajp
@@ -56,14 +56,14 @@ ajp_Arab:
   datasets:
     flores_dev: ok
     flores_devtest: ok
-aka_Latn:
-  name: Akan
-  glottocode: akan1250
-  iso_639_3: aka
+twi_Latn_asan1239:
+  name: Asante Twi
+  glottocode: asan1239
+  iso_639_3: twi
   iso_15924: Latn
   datasets:
-    flores_dev: warn
-    flores_devtest: warn
+    flores_dev: ok
+    flores_devtest: ok
 als_Latn:
   name: Tosk Albanian
   glottocode: tosk1239
@@ -80,7 +80,7 @@ amh_Ethi:
   datasets:
     flores_dev: ok
     flores_devtest: ok
-apc_Arab:
+apc_Arab_nort3139:
   name: North Levantine Arabic
   glottocode: nort3139
   iso_639_3: apc
@@ -449,7 +449,7 @@ epo_Latn:
   datasets:
     flores_dev: ok
     flores_devtest: ok
-est_Latn:
+ekk_Latn:
   name: Estonian
   glottocode: kesk1234
   iso_639_3: ekk
@@ -563,7 +563,7 @@ gom_Deva:
   datasets:
     flores_dev: ok
     flores_devtest: ok
-grn_Latn:
+gug_Latn:
   name: Paraguayan Guaraní
   glottocode: para1311
   iso_639_3: gug
@@ -849,7 +849,7 @@ kmr_Latn:
   datasets:
     flores_dev: ok
     flores_devtest: ok
-kon_Latn:
+ktu_Latn:
   name: Kituba (DRC)
   glottocode: kitu1246
   iso_639_3: ktu
@@ -1243,8 +1243,8 @@ pol_Latn:
     flores_dev: ok
     flores_devtest: ok
 por_Latn:
-  name: Portuguese
-  glottocode: port1283
+  name: Brazilian Portuguese
+  glottocode: braz1246
   iso_639_3: por
   iso_15924: Latn
   datasets:
@@ -1414,8 +1414,8 @@ sot_Latn:
     flores_dev: ok
     flores_devtest: ok
 spa_Latn:
-  name: Spanish
-  glottocode: stan1288
+  name: Latin American Spanish
+  glottocode: amer1254
   iso_639_3: spa
   iso_15924: Latn
   datasets:
@@ -1595,9 +1595,9 @@ tur_Latn:
   datasets:
     flores_dev: ok
     flores_devtest: ok
-twi_Latn:
-  name: Twi
-  glottocode: twii1234
+twi_Latn_akua1239:
+  name: Akuapem Twi
+  glottocode: akua1239
   iso_639_3: twi
   iso_15924: Latn
   datasets:

--- a/static/style.css
+++ b/static/style.css
@@ -85,7 +85,8 @@ img.i { height: 2ex; vertical-align: middle; }
 
 a { color: var(--blue);  }
 a:hover { text-decoration: none; }
-th a { color: black; }
+
+th a, code a { color: black; }
 
 code {
     font-family: 'Courier New', Courier, monospace;

--- a/templates/languages.html
+++ b/templates/languages.html
@@ -21,9 +21,9 @@
     <tbody>
         {% for lang in languages -%}
         <tr>
-            <td><code>{{ lang.iso_639_3 }}</code></td>
+            <td><code><a href="https://iso639-3.sil.org/code/{{ lang.iso_639_3 }}">{{ lang.iso_639_3 }}</a></code></td>
             <td><code>{{ lang.iso_15924 }}</code></td>
-            <td>{% if lang.glottocode %}<code>{{ lang.glottocode }}</code>{% endif %}</td>
+            <td>{% if lang.glottocode %}<code><a href="https://glottolog.org/resource/languoid/id/{{ lang.glottocode }}">{{ lang.glottocode }}</a></code>{% endif %}</td>
             <td>{{ lang.name }}</td>
             <td>
                 {%- if lang.datasets.flores_dev == "ok" and lang.datasets.flores_devtest == "ok" -%}


### PR DESCRIPTION
* Update the following codes:
  * est_Latn —> ekk_Latn
  * grn_Latn —> gug_Latn
  * kon_Latn —> ktu_Latn
  * ajp_Arab —> apc_Arab_sout3123
  * apc_Arab —> apc_Arab_nort3139
  * aka_Latn —> twi_Latn_asan1239
  * twi_Latn —> twi_Latn_akua1239
* In the table, add links from Glottocodes to the corresponding entry in Glottolog, and from ISO 639-3 codes to the corresponding page on the SIL ISO 639-3 website.
* Rename Portuguese to Brazilian Portuguese and Spanish to Latin American Spanish (with corresponding Glottocodes) as we know that these are the variants which were used for FLORES.