### PR TITLE
Add all the dataset cards into the website repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The build process is straightforward:
 1. We load all language metadata from `languages.yaml`, and copy it to the build directory (so it can be accessed by the public).
 2. We copy all static content in `static/` to the build directory.
 3. We compile all templates in `templates/` to the build directory.
+4. We feed all dataset cards in `dataset_cards/` into the `dataset_card.html` template and compile to the build directory (after any update, they need to be manually copypasted from the FLORES and Seed repositories).
 
 ### Local builds
 

--- a/build.py
+++ b/build.py
@@ -4,10 +4,15 @@ from pathlib import Path
 
 import yaml
 from jinja2 import Environment, PackageLoader, select_autoescape
+import mistune
 
 STATIC_ROOT = Path("./static")
 TEMPLATE_ROOT = Path("./templates")
 BUILD_ROOT = Path("./build")
+CARDS_ROOT = Path("dataset_cards")
+# TODO: maybe git submodule from the other repositories, instead of copying the cards directory
+SEED_CARDS_URL = "https://huggingface.co/datasets/openlanguagedata/oldi_seed/blob/main/dataset_cards"
+FLORES_CARDS_URL = "https://huggingface.co/datasets/openlanguagedata/flores_plus/blob/main/dataset_cards"
 
 # Copy all static content to the build directory
 shutil.rmtree(BUILD_ROOT, ignore_errors=True)
@@ -19,13 +24,54 @@ with open("languages.yaml") as f:
     languages = dict(sorted(yaml.safe_load(f).items()))
 shutil.copy("languages.yaml", BUILD_ROOT)
 
+# Read the FLORES+ and Seed dataset cards and attach them to the languages
+data2langs2cards = {}  # {dataset name => lang name => dataset card}
+for data_cards_path in CARDS_ROOT.iterdir():
+    data_name = data_cards_path.name  # flores or seed
+    lang2cards = {}
+    for lang_path in data_cards_path.iterdir():
+        lang = lang_path.stem
+        with open(lang_path, "r") as f:
+            card_md = f.read()
+        if lang in languages:
+            lang2cards[lang] = card_md
+            languages[lang][f"{data_name}_card"] = f"/cards/{data_name}/{lang}.html"
+        else:
+            print(f"Warning: language `{lang}` was found in {data_name} dataset cards, but not in languages.yaml; skipping it.")
+    data2langs2cards[data_name] = lang2cards
+
+md_renderer = mistune.create_markdown(
+    escape=False,
+    plugins=['strikethrough', 'footnotes', 'table', 'url']
+)
+
 # Compile every template you find
 env = Environment(loader=PackageLoader("build"), autoescape=select_autoescape())
 for template in TEMPLATE_ROOT.glob("**/*.html"):
     template_path = template.relative_to(TEMPLATE_ROOT)
     tgt_dir = BUILD_ROOT / template_path.parent
     tgt_dir.mkdir(parents=True, exist_ok=True)
-    tgt_file = tgt_dir / template.name
     template = env.get_template(str(template_path))
-    with open(tgt_file, "wt") as f:
-        print(template.render(languages=languages.values()), file=f)
+
+    if template_path.name == "dataset_card.html":
+        # the dataset card template is applied for every dataset card
+        for data_name, lang2cards in data2langs2cards.items():
+            cards_tgt_dir = tgt_dir / "cards" / data_name
+            cards_tgt_dir.mkdir(parents=True, exist_ok=True)
+            for lang_id, card_md in lang2cards.items():
+                card_html = md_renderer(card_md)
+                tgt_file = cards_tgt_dir / f"{lang_id}.html"
+                lang = languages[lang_id]
+                if data_name == "seed":
+                    orig_url = f"{SEED_CARDS_URL}/{lang_id}.md"
+                elif data_name == "flores":
+                    orig_url = f"{FLORES_CARDS_URL}/{lang_id}.md"
+                else:
+                    orig_url = None
+                with open(tgt_file, "wt") as f:
+                    print(template.render(card_content=card_html, lang=lang, orig_url=orig_url), file=f)
+    else:
+        # for all other templates, render them just once
+        tgt_file = tgt_dir / template.name
+        with open(tgt_file, "wt") as f:
+            print(template.render(languages=languages.values()), file=f)

--- a/dataset_cards/flores/arg_Latn.md
+++ b/dataset_cards/flores/arg_Latn.md
@@ -1,0 +1,51 @@
+# Dataset card
+
+## Description
+
+FLORES+ dev and devtest sets in Aragonese.
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+```bibtex
+@inproceedings{wmt24-spain,
+    title="Expanding the FLORES+ Multilingual Benchmark with Translations for {Aragonese, Aranese, Asturian, and Valencian}",
+    author="Juan Antonio Perez-Ortiz and Felipe S{\'a}nchez-Martínez and Víctor M. S{\'a}nchez-Cartagena and Miquel Esplà-Gomis and Aaron Galiano Jimenez and Antoni Oliver and Claudi Aventín-Boya and Alejandro Pardos and Cristina Valdés and Jus{\'e}p Loís Sans Socasau and Juan Pablo Martínez",
+    booktitle = "Proceedings of the Ninth Conference on Machine Translation",
+    month = nov,
+    year = "2024",
+    address = "Miami, USA",
+    publisher = "Association for Computational Linguistics"
+}
+```
+
+With the support of the R+D+i projects PID2021-127999NB-I00 (LiLowLa: Lightweight neural translation technologies for low-resource languages) and PID2021-124663OB-I00 (TAN-IBE: Neural Machine Translation for the Romance languages of the Iberian Peninsula), funded by MCIN /AEI /10.13039/501100011033 / FEDER, UE.
+
+## Language codes
+
+* ISO-639-3: arg
+* ISO 15924: Latn
+* Glottocode: arag1245
+
+## Additional language information
+
+* [Academia de l'Aragonés](http://www.academiadelaragones.org)
+* [Orthography of Aragonese](https://academiaaragonesadelalengua.org/sites/default/files/ficheros-pdf/ortografia-de-laragones_web_an.pdf), published by EFA-ACAR (Estudio de Filología Aragonesa – Academia de l’Aragonés). 
+*  [Grammar of Aragonese](http://www.academiadelaragones.org/biblio/Edacar10_GBAprovisional.pdf), published by EFA-ACAR.
+* [Dictionary of Aragonese](http://www.academiadelaragones.org/biblio/Edacar13.pdf) published by EFA-ACAR. 
+* Aragonese dictionary [Tresoro d'a Luenga Aragonesa](http://diccionario.sipca.es/fabla/faces/index.xhtml).
+* Spanish--Aragonese and Aragonese--Spanish dictionary  [Aragonario](\url{https://aragonario.aragon.es/), developed under the project LINGUATEC and published by the Government of Aragon. 
+* [Spanish-Aragonese machine translation system](https://github.com/apertium/apertium-spa-arg)
+
+## Workflow
+
+The data for Aragonese was initially translated from Spanish using the Spanish-Aragonese Apertium rule-based machine translation system. This translation was subsequently post-edited by specialists proficient in Aragonese. The utilization of machine translation is justified for two reasons: firstly, the two-step workflow consisting of machine translation followed by post-editing is prevalent for this language, with many existing texts being produced this way; secondly, sourcing linguists or translators for Aragonese proved challenging due to their scarcity, making it difficult to complete the task within the required timeframe.
+
+Finally, the post-edited translation was reviewed by a member of the *Academia Aragonesa de la Lengua*. In this last step, the reviewer had also in view the English version of the FLORES+ dataset; an important number of translations were modified for better agreement with English original data.  
+
+## Additional guidelines
+
+The guidelines provided by the Academia de l'Aragonés were followed to ensure that the translation into Aragonese aligned with their recommendations.

--- a/dataset_cards/flores/ast_Latn.md
+++ b/dataset_cards/flores/ast_Latn.md
@@ -1,0 +1,45 @@
+# Dataset card
+
+## Description
+
+FLORES+ dev and devtest sets in Asturian.
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+```bibtex
+@inproceedings{wmt24-spain,
+    title="Expanding the FLORES+ Multilingual Benchmark with Translations for {Aragonese, Aranese, Asturian, and Valencian}",
+    author="Juan Antonio Perez-Ortiz and Felipe S{\'a}nchez-Martínez and Víctor M. S{\'a}nchez-Cartagena and Miquel Esplà-Gomis and Aaron Galiano Jimenez and Antoni Oliver and Claudi Aventín-Boya and Alejandro Pardos and Cristina Valdés and Jus{\'e}p Loís Sans Socasau and Juan Pablo Martínez",
+    booktitle = "Proceedings of the Ninth Conference on Machine Translation",
+    month = nov,
+    year = "2024",
+    address = "Miami, USA",
+    publisher = "Association for Computational Linguistics"
+}
+```
+
+With the support of the R+D+i projects PID2021-127999NB-I00 (LiLowLa: Lightweight neural translation technologies for low-resource languages) and PID2021-124663OB-I00 (TAN-IBE: Neural Machine Translation for the Romance languages of the Iberian Peninsula), funded by MCIN /AEI /10.13039/501100011033 / FEDER, UE.
+
+## Language codes
+
+* ISO-639-3: ast
+* ISO 15924: Latn
+* Glottocode: astu1246
+
+## Additional language information
+
+* [Diccionariu de la Llingua Asturiana](https://diccionariu.alladixital.org)
+* [Gramática de la Llingua Asturiana](https://alladixital.org/wp-content/uploads/2022/08/Gramatica-de-la-Llingua-Asturiana.pdf)
+* [Normes ortográfiques](https://alladixital.org/wp-content/uploads/2024/01/Normes-Ortografiques-8a-edicion-FINAL-3.pdf)
+
+## Workflow
+
+The Asturian sentences were originally obtained by Meta via professional translation from English using professional translators as part of their *no language left behind*. We had this translation into Asturian reviewed by native speakers, some of whom are members of the *Academia de la Llingua Asturiana*, philologists and  a renowned writer, translator, and activist for the Asturian language. The revision process was carried out twice by different people. In the first round, the reviewers were presented with the Spanish text and the existing version of the Asturian FLORES+, and in the second round, with the Spanish FLORES+ version and the first revised version.
+
+## Additional guidelines
+
+The guidelines provided by the Academia de la Llingua Asturiana were followed to ensure that the translation into Asturian aligned with their recommendations.

--- a/dataset_cards/flores/cat_Latn_vale1252.md
+++ b/dataset_cards/flores/cat_Latn_vale1252.md
@@ -1,0 +1,50 @@
+# Dataset card
+
+## Description
+
+FLORES+ devtest set in the Valencian dialect of Catalan
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+```bibtex
+@inproceedings{wmt24-spain,
+    title="Expanding the FLORES+ Multilingual Benchmark with Translations for {Aragonese, Aranese, Asturian, and Valencian}",
+    author="Juan Antonio Perez-Ortiz and Felipe S{\'a}nchez-Martínez and Víctor M. S{\'a}nchez-Cartagena and Miquel Esplà-Gomis and Aaron Galiano Jimenez and Antoni Oliver and Claudi Aventín-Boya and Alejandro Pardos and Cristina Valdés and Jus{\'e}p Loís Sans Socasau and Juan Pablo Martínez",
+    booktitle = "Proceedings of the Ninth Conference on Machine Translation",
+    month = nov,
+    year = "2024",
+    address = "Miami, USA",
+    publisher = "Association for Computational Linguistics"
+}
+```
+
+With the support of the project CENID2023/10, funded by Diputació d'Alacant; and the R+D+i project PID2021-127999NB-I00 (LiLowLa: Lightweight neural translation technologies for low-resource languages), funded by MCIN /AEI /10.13039/501100011033 / FEDER, UE.
+
+## Language codes
+
+* ISO 639-3: cat
+* ISO 15924: Latn
+* Glottocode: vale1252
+
+## Additional language information
+
+* [LanguageTool](https://languagetool.org/ca) grammar corrector
+* [Llista diatòpica del lèxic català](https://ca.wikipedia.org/wiki/Llista_diat%C3%B2pica_del_l%C3%A8xic_catal%C3%A0): list of lexical items that change between the different dialects of the Catalan language
+* [Diccionari normatiu valencià](https://www.avl.gva.es/lexicval/): dictionary of the Valencian Language Academy
+* [Criteris lingüístics per als usos institucionals de les universitats valencianes](https://sl.ua.es/en/assessorament/documentos/criteris-linguistics.pdf): Linguistic criteria for the institutional use of Valencian dialect in the Valencian universities
+
+
+## Workflow
+
+The dataset was created by adapting the existing Catalan version of the FLORES+ devtest set. The work was carried out by a single native speaker of the Valencian dialect. The native speaker holds a Ph.D. and has experience in translating into Valencian and reviewing texts in Valencian. 
+
+In order to speed up the process, LanguageTool was used to introduce an initial set of changes to the original text. Then, all these changes were manually checked, and other required changes were manually applied, taking into account the aforementioned list of lexical items that change between the different dialects of the Catalan language. In case of doubt, the dictionary of the Valencian Language Academy was checked.
+
+## Additional guidelines
+
+Linguistic criteria for the institutional use of the Valencian dialect in the Valencian universities were followed.
+

--- a/dataset_cards/flores/chv_Cyrl.md
+++ b/dataset_cards/flores/chv_Cyrl.md
@@ -1,0 +1,34 @@
+# Dataset card
+
+## Description
+
+FLORES+ in Chuvash
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+The translation was contributed by the team of Chuvash language laboratory: https://en.corpus.chv.su/content/about.html.
+
+## Language codes
+
+* ISO 639-3: chv
+* ISO 15924: Cyrl
+* Glottocode: chuv1255
+
+
+## Additional language information
+
+The linguistic landscape of the Chuvash language is quite homogeneous, the differences between the dialects are insignificant.
+
+Some additional resources in Chuvash are below: 
+
+- Parallel corpora with Russian and English: https://github.com/AlAntonov/chv_corpus
+- A digital dictionary: http://samahsar.chuvash.org/
+
+## Workflow
+
+Data was translated from Russian by one translator, a native speaker of the target language. 100% of the data was checked by one more independent translator.
+Dev and devtest datasets were translated by 2 independent translators

--- a/dataset_cards/flores/cmn_Hans.md
+++ b/dataset_cards/flores/cmn_Hans.md
@@ -1,0 +1,33 @@
+# Dataset card
+
+## Description
+
+FLORES+ in Standard Beijing Mandarin (Simplified script)
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+```bibtex
+@article{flores101-22,
+    title = {The {F}lores-101 Evaluation Benchmark for Low-Resource and Multilingual Machine Translation},
+    author = {Goyal, Naman and Gao, Cynthia and Chaudhary, Vishrav and Chen, Peng-Jen and Wenzek, Guillaume and Ju, Da and Krishnan, Sanjana and Ranzato, Marc’Aurelio and Guzmán, Francisco and Fan, Angela},
+    journal = {Transactions of the Association for Computational Linguistics},
+    volume = {10},
+    year = {2022},
+}
+```
+
+## Language codes
+
+* ISO 639-3: cmn
+* ISO 15924: Hans
+* Glottocode: beij1234
+
+## Additional language information
+
+## Workflow
+
+This data was released as part of the FLORES-101 dataset, where it was labeled `zho_simpl`. Please refer to the paper for further information.

--- a/dataset_cards/flores/cmn_Hant.md
+++ b/dataset_cards/flores/cmn_Hant.md
@@ -1,0 +1,33 @@
+# Dataset card
+
+## Description
+
+FLORES+ in Taiwanese Mandarin (Traditional script)
+
+## License
+
+CC-BY-SA-4.0
+
+## Data attribution
+
+```bibtex
+@article{flores101-22,
+    title = {The {F}lores-101 Evaluation Benchmark for Low-Resource and Multilingual Machine Translation},
+    author = {Goyal, Naman and Gao, Cynthia and Chaudhary, Vishrav and Chen, Peng-Jen and Wenzek, Guillaume and Ju, Da and Krishnan, Sanjana and Ranzato, Marc’Aurelio and Guzmán, Francisco and Fan, Angela},
+    journal = {Transactions of the Association for Computational Linguistics},
+    volume = {10},
+    year = {2022},
+}
+```
+
+## Language codes
+
+* ISO 639-3: cmn
+* ISO 15924: Hant
+* Glottocode: taib1240
+
+## Additional language information
+
+## Workflow
+
+This data was released as part of the FLORES-101 dataset, where it was labeled `zho_trad`. Please refer to the paper for further information.

--- a/dataset_cards/flores/dar_Cyrl.md
+++ b/dataset_cards/flores/dar_Cyrl.md
@@ -1,0 +1,32 @@
+# Dataset card
+
+## Description
+
+FLORES+ dev set in Dargwa
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+Yusupov Khizri (h-yusupov@mail.ru), Rabadangadzhiev Murtazali (murtuzali1996@yandex.ru)
+
+## Language codes
+
+* ISO 639-3: dar
+* ISO 15924: Cyrl
+* Glottocode: darg1241
+
+## Additional language information
+
+Dargwa is a Northeast Caucasian language spoken by about 485,000 people, primarily in the Republic of Dagestan in the Russian Federation. It is one of the official languages of Dagestan and is also used in education and media in the region.
+
+Some additional resources in Dargwa are below: 
+
+- A monolingual corpus for Dargwa: http://lingconlab.ru/standard_dargwa/
+- A Dargwa-Russian digital dictionary: https://t.me/dargwa_lingvo_bot
+
+## Workflow
+
+The data was translated from Russian by Yusupov Khizri, Doctor of Philological Sciences and a native speaker of the target language. The translation was checked by another independent native speaker, Rabadangadzhiev Murtazali.

--- a/dataset_cards/flores/fil_Latn.md
+++ b/dataset_cards/flores/fil_Latn.md
@@ -1,0 +1,33 @@
+# Dataset card
+
+## Description
+
+FLORES+ in Filipino
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+```bibtex
+@article{flores101-22,
+    title = {The {F}lores-101 Evaluation Benchmark for Low-Resource and Multilingual Machine Translation},
+    author = {Goyal, Naman and Gao, Cynthia and Chaudhary, Vishrav and Chen, Peng-Jen and Wenzek, Guillaume and Ju, Da and Krishnan, Sanjana and Ranzato, Marc’Aurelio and Guzmán, Francisco and Fan, Angela},
+    journal = {Transactions of the Association for Computational Linguistics},
+    volume = {10},
+    year = {2022},
+}
+```
+
+## Language codes
+
+* ISO 639-3: fil
+* ISO 15924: Latn
+* Glottocode: fili1244
+
+## Additional language information
+
+## Workflow
+
+This data was released as part of the FLORES-101 dataset, where it was labeled `tgl`. Please refer to the paper for further information.

--- a/dataset_cards/flores/kaa_Latn.md
+++ b/dataset_cards/flores/kaa_Latn.md
@@ -1,0 +1,41 @@
+# Dataset card
+
+## Description
+
+FLORES+ devtest set in Karakalpak
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+Mukhammadsaid Mamasaidov (m.mamasaidov@tahrirchi.uz), Abror Shopulatov (a.shopulatov@tahrirchi.uz).
+
+```bibtex
+@inproceedings{wmt24-karakalpak,
+    title="{Open Language Data Initiative}: Advancing Low-Resource Machine Translation for {Karakalpak}",
+    author="Mukhammadsaid Mamasaidov and Abror Shopulatov",
+    booktitle = "Proceedings of the Ninth Conference on Machine Translation",
+    month = nov,
+    year = "2024",
+    address = "Miami, USA",
+    publisher = "Association for Computational Linguistics"
+}
+```
+
+## Language codes
+
+* ISO 639-3: kaa
+* ISO 15924: Latn
+* Glottocode: kara1467
+
+## Additional language information
+
+Karakalpak is a Turkic language belonging to the Kipchak branch. It is primarily spoken in the Republic of Karakalpakstan, an autonomous region within Uzbekistan, Central Asia. The language has approximately 900,000 native speakers. Karakalpak is closely related to Kazakh and Nogai languages.
+
+The FLORES+ devtest set dataset is translated into the standardized literary version of Karakalpak using the most recent Latin script orthography. It's worth noting that Karakalpak uses both Cyrillic and Latin scripts, with the Latin script introduced in 1995 and undergoing several revisions, most notably in 2009 and 2016.
+
+## Workflow
+
+The FLORES+ devtest dataset, consisting of 1012 sentences, was translated from English and Russian into Karakalpak by two annotators. The translations were then cross-verified to ensure accuracy. The dataset adheres to the most recent iteration of the Latin script orthography for Karakalpak.

--- a/dataset_cards/flores/lij_Latn.md
+++ b/dataset_cards/flores/lij_Latn.md
@@ -1,0 +1,40 @@
+# Data card
+
+## Description
+
+FLORES+ in Genoese Ligurian
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+```bibtex
+@article{nllb-22,
+    title = {No Language Left Behind: Scaling Human-Centered Machine Translation},
+    author = {{NLLB Team} and Costa-jussà, Marta R. and Cross, James and Çelebi, Onur and Elbayad, Maha and Heafield, Kenneth and Heffernan, Kevin and Kalbassi, Elahe and Lam, Janice and Licht, Daniel and Maillard, Jean and Sun, Anna and Wang, Skyler and Wenzek, Guillaume and Youngblood, Al and Akula, Bapi and Barrault, Loic and Mejia-Gonzalez, Gabriel and Hansanti, Prangthip and Hoffman, John and Jarrett, Semarley and Sadagopan, Kaushik Ram and Rowe, Dirk and Spruit, Shannon and Tran, Chau and Andrews, Pierre and Ayan, Necip Fazil and Bhosale, Shruti and Edunov, Sergey and Fan, Angela and Gao, Cynthia and Goswami, Vedanuj and Guzmán, Francisco and Koehn, Philipp and Mourachko, Alexandre and Ropers, Christophe and Saleem, Safiyyah and Schwenk, Holger and Wang, Jeff},
+    year = {2022},
+    eprint = {arXiv:1902.01382},
+}
+```
+
+## Language codes
+
+* ISO 639-3: lij
+* ISO 15924: Latn
+* Glottocode: geno1240
+
+## Additional language information
+
+The data is in the Genoese dialect, using traditional spelling as codified in the following reference dictionaries:
+* S. Lusito (2022) Dizionario italiano-genovese, Programma, ISBN 9788866438205.
+* The Council for Ligurian Linguistic Heritage’s [online Italian-Genoese dictionary](https://conseggio-ligure.org/en/dictionary/deize/).
+* E. Autelli, S. Lusito, C. Konecny, F. Toso (2018-2021) [GEPHRAS](https://romanistik-gephras.uibk.ac.at/).
+
+Reference grammar:
+* F. Toso (1997) Grammatica del genovese: varietà urbana e di koinè, Le Mani, ISBN 9788880120728.
+
+## Workflow
+
+This data was released as part of the FLORES-200 dataset. It has undergone minor spelling and syntactic fixes following community feedback and additional quality assessment. Please refer to the paper for further information.

--- a/dataset_cards/flores/mhr_Cyrl.md
+++ b/dataset_cards/flores/mhr_Cyrl.md
@@ -1,0 +1,30 @@
+# Dataset card
+
+## Description
+
+FLORES+ dev set in Meadow Mari
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+## Language codes
+
+* ISO 639-3: mhr
+* ISO 15924: Cyrl
+* Glottocode: gras1239
+
+## Additional language information
+
+Mari is a Uralic language spoken by about 451,000 people mainly in Mari El Republic in the west of the Russian Federation, and also in Bashkortostan, Tatarstan, Udmurtia, Perm and other parts of the Russian Federation. There are three standard forms of Mari: Hill Mari, Meadow Mari and Northwestern Mari, with significant differences between them. Eastern Mari is a fourth dialect, sharing the written standard with Meadow Mari, but different phonologically.
+
+Some additional resources in Meadow Mari are below: 
+
+- A parallel corpus with Russian: https://huggingface.co/datasets/AigizK/mari-russian-parallel-corpora
+- A monolingual corpus composed of various genres: https://huggingface.co/datasets/mari-lab/mari-monolingual-corpus
+
+## Workflow
+
+Data was translated from Russian by one translator, a native speaker of the target language. 100% of the data was checked by one more independent translator.

--- a/dataset_cards/flores/myv_Cyrl.md
+++ b/dataset_cards/flores/myv_Cyrl.md
@@ -1,0 +1,45 @@
+# Dataset card
+
+## Description
+
+FLORES+ dev and devtest sets in Erzya
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+Sergey Kuldin (sergey@kuldin.com).
+
+```bibtex
+@inproceedings{wmt24-erzya,
+    title="FLORES+ translation and machine translation evaluation for the {E}rzya language",
+    author="Isai Gordeev and Sergey Kuldin and David Dale",
+    booktitle = "Proceedings of the Ninth Conference on Machine Translation",
+    month = nov,
+    year = "2024",
+    address = "Miami, USA",
+    publisher = "Association for Computational Linguistics"
+}
+```
+
+## Language codes
+
+* ISO 639-3: myv
+* ISO 15924: Cyrl
+* Glottocode: erzy1239
+
+## Additional language information
+
+Erzya is one of the largest Finno-Ugric languages, belonging to the Mordvinic branch of the Uralic language family. The FLORES dataset is translated into the literary version of the language, which is based on the Central dialect of Erzya. Erzya is spoken by about 300,000 people in the Russian Federation, with several tens of thousands of speakers in other countries, particularly in Kazakhstan, Uzbekistan, Tajikistan, Kyrgyzstan, and Turkmenistan. Despite its official status in the Republic of Mordovia, where Erzya is used in education and media, the language faces challenges in intergenerational transmission and digital presence. However, some digital resources exist:
+
+- Erzya Wikipedia: https://myv.wikipedia.org
+- Machine translator with support for Erzya: https://lango.to
+- Erzya language corpus: https://erzya.web-corpora.net/
+- A corpus of parallel Erzya-Russian words, phrases and sentences: https://huggingface.co/datasets/slone/myv_ru_2022
+- Erzya and Moksha Extended Corpora (ERME): https://www.kielipankki.fi/corpora/erme/
+
+## Workflow
+
+The FLORES+ dataset was translated from Russian into the Erzya language by two native speakers who are also teachers of the language and writers (one holding a doctoral degree in philology). The 250 translated sentences from Yankovskaya et al. (https://aclanthology.org/2023.nodalida-1.77/) were also included after a thorough revision. All translations were reviewed by one of the native translators and a linguist with profound expertise in the language.

--- a/dataset_cards/flores/oci_Latn_aran1260.md
+++ b/dataset_cards/flores/oci_Latn_aran1260.md
@@ -1,0 +1,54 @@
+# Dataset card
+
+## Description
+
+FLORES+ dev and devtest sets in Aranese.
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+```bibtex
+@inproceedings{wmt24-erzya,
+    title="FLORES+ translation and machine translation evaluation for the {E}rzya language",
+    author="Isai Gordeev and Sergey Kuldin and David Dale",
+    booktitle = "Proceedings of the Ninth Conference on Machine Translation",
+    month = nov,
+    year = "2024",
+    address = "Miami, USA",
+    publisher = "Association for Computational Linguistics"
+}
+```
+
+With the support of the R+D+i projects PID2021-127999NB-I00 (LiLowLa: Lightweight neural translation technologies for low-resource languages) and PID2021-124663OB-I00 (TAN-IBE: Neural Machine Translation for the Romance languages of the Iberian Peninsula), funded by MCIN /AEI /10.13039/501100011033 / FEDER, UE.
+
+## Language codes
+
+* ISO-639-3: oci
+* ISO 15924: Latn
+* Glottocode: aran1260
+
+## Additional language information
+
+* [Institut d'Estudis Aranesi](https://en.wikipedia.org/wiki/Aranese_dialect)
+* [Catalan-Aranese machine translation system](https://github.com/apertium/apertium-oci-cat)
+* [Dictionary for Aranese](http://www.institutestudisaranesi.cat/wp-content/uploads/2021/04/DICCIONARI-DER-ARAN%C3%89S.pdf); [erratum 2021](http://www.institutestudisaranesi.cat/wp-content/uploads/2020/12/ERRATA-WEB.pdf); [extension 2021](http://www.institutestudisaranesi.cat/wp-content/uploads/2020/12/500-1-g%C3%A8r-2021-WEB.pdf); [extension 2022](http://www.institutestudisaranesi.cat/wp-content/uploads/2022/01/WEB-AMPLIACION-01-01-2022.pdf); [extension 2023](http://www.institutestudisaranesi.cat/wp-content/uploads/2023/03/Ampliacion-2023.pdf)
+* [Grammar for Aranaese](http://www.institutestudisaranesi.cat/wp-content/uploads/2021/04/gramatica-aranes.pdf)
+* [Orthographic vocabulary](http://www.institutestudisaranesi.cat/wp-content/uploads/2019/11/33520-vocabulari-ortografic.pdf)
+* [Winter sports vocabulary](http://www.institutestudisaranesi.cat/wp-content/uploads/2019/11/33288-vocabulari-esports-iuern.pdf)
+* [Computer and informatics vocabulary](http://www.institutestudisaranesi.cat/wp-content/uploads/2018/11/TECNOLOGIA.pdf)
+* [Aranese verbs](http://www.institutestudisaranesi.cat/wp-content/uploads/2019/11/33287-els-ve%CC%80rbs.pdf)
+
+## Workflow
+
+The data was initially translated from Catalan using the Apertium rule-based machine translation system for Catalan-Aranese. The translation was then manually post-edited by native speakers of Aranese with three years of experience translating texts on diverse topics into Aranese. Finally, the post-edited translation was reviewed by different individuals, who are also native speakers, from the Institut d'Estudis Aranesi.
+
+The data was initially obtained by translating the sentences in the Catalan FLORES+ dev and devtest datasets using the Apertium rule-based MT system for Catalan-Aranese. A revision process was then performed in two steps. Firstly, a professional reviewer with wide experience in translation and revision with proficiency in Aranese was presented with the French, Catalan and Occitan versions of the FLORES+, along with the machine translated version into Aranese. Finally, the post-edited translation was reviewed by different individuals, who are native speakers, from the Institut d'Estudis Aranesi (IEA). 
+
+The utilization of machine translation is justified for two reasons: firstly, the two-step workflow consisting of machine translation followed by post-editing is prevalent for this language, with many existing texts being produced this way; secondly, sourcing linguists or translators for Aranese proved challenging due to their scarcity, making it difficult to complete the task within the required timeframe.
+
+## Additional guidelines
+
+The guidelines provided by the Institut d'Estudis Aranesi were followed to ensure that the translation into Aranese aligned with their recommendations.

--- a/dataset_cards/flores/tyv_Cyrl.md
+++ b/dataset_cards/flores/tyv_Cyrl.md
@@ -1,0 +1,61 @@
+# Dataset card
+
+## Description
+
+FLORES+ dev set in Tuvan (Tyvan)
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+The translation was contributed by the team of [Tyvan.ru](https://tyvan.ru/).
+
+```bibtex
+@inproceedings{wmt24-tuvan,
+    title="Enhancing {Tuvan} Language Resources through the {FLORES} Dataset",
+    author="Ali Kuzhuget and Airana Mongush and Nachyn-Enkhedorzhu Oorzhak",
+    booktitle = "Proceedings of the Ninth Conference on Machine Translation",
+    month = nov,
+    year = "2024",
+    address = "Miami, USA",
+    publisher = "Association for Computational Linguistics"
+}
+```
+
+## Language codes
+
+* ISO 639-3: tyv
+* ISO 15924: Cyrl
+* Glottocode: tuvi1240
+
+## Additional language information
+
+The linguistic landscape of the Tuvan language is quite homogeneous, the differences between the dialects in the Republic of Tyva are insignificant. There are Tuvan speaking small communities in the People's Republic of China and Mongolia, they have many distinguished features.
+
+Some additional resources in Tuvan are below: 
+
+- The first Tuvan-Russian AI-translator, bidirectional dictionaries: https://tyvan.ru/
+- The project containing important data for Russian-Tuvan and vice versa translations: https://github.com/Agisight/TyvaData
+- Russian-Tuvan parallel data set with 50k translations: https://tyvan.ru/machineLearning/rus_tyv_parallel_50k.tsv
+- Tyvan.ru iOS app: https://itunes.apple.com/ru/app/tyv-rus/id1023486602?mt=8 
+- **Тыва-орус сөстүк** – Android tyv-rus dictionary app: https://play.google.com/store/apps/details?id=ru.tuvlin.tyv_rus_android
+- Tuvan Wikipedia: https://tyv.wikipedia.org/
+- The Russian community dedicated to helping people digitize and preserve their language electronically – **Языки разные - код один**
+- The LANGO.TO project, developed by a team of enthusiasts in NLP, aims to preserve and promote the languages of minority peoples. https://lango.to/
+
+## Workflow
+
+Data was translated from Russian by several translators, native speakers of the target language: **Моңгуш Салим** (telegram: @renegenone), **Ооржак Людмила**, **Оңгай-оол Чодураа**, **Күжүгет Али** (telegram: @Agilight). Many translations have been double-checked by Али.
+
+## Contacts
+
+Feel free to join in and discuss any Tuvan (Tyvan) data and ideas. 
+
+**Ali Kuzhuget**, telegram: @Agilight.
+Git: https://github.com/Agisight/
+
+**Aira Mongush**: https://airamongush.com/
+
+**David Dale**, telegram: @cointegrated.

--- a/dataset_cards/flores/vmw_Latn.md
+++ b/dataset_cards/flores/vmw_Latn.md
@@ -1,0 +1,50 @@
+# Dataset card
+
+## Description
+
+FLORES+ dev and devtest set in Emakhuwa
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+```bibtex
+@inproceedings{wmt24-emakhuwa,
+    title="Expanding {FLORES+} Benchmark for more Low-Resource Settings: {Portuguese-Emakhuwa} Machine Translation Evaluation",
+    author="Felermino Dario Mario Ali and Henrique Lopes Cardoso and Rui Sousa-Silva",
+    booktitle = "Proceedings of the Ninth Conference on Machine Translation",
+    month = nov,
+    year = "2024",
+    address = "Miami, USA",
+    publisher = "Association for Computational Linguistics"
+}
+```
+
+## Language codes
+
+* ISO 639-3: vmw
+* ISO 15924: Latn
+* Glottocode: cent2033
+
+## Workflow
+
+Data was translated from Portuguese by 2 translators, all bilingual speakers of the languages. All translators were professional translators. 100% of the data was checked by three more independent translator.
+
+The workflow is divided into three main steps:
+
+1. **Data Preparation**: 
+   - Sentences from the *devtest* and *dev* sets are compiled into segments and loaded into the Matecat CAT tool.
+   - Guidelines and a glossary were prepared to standardize the translation process. The guidelines were adapted from the OLDI guidelines and written in Portuguese, focusing on the central variant of Emakhuwa. The glossary was created by digitizing existing bilingual dictionaries and a glossary from Radio of Mozambique, ensuring consistent translations and minimizing loanword use.
+
+2. **Translation**:
+   - The translation tasks were divided between two translators. They used a spell checker system to identify potential misspellings, which were then corrected based on feedback.
+   
+3. **Validation**:
+   - This step included revision and judgments. The translated works were exchanged between translators for post-editing.
+   - Direct Assessment was also used, where three raters evaluated the translation's adequacy on a scale from 0 to 100, to measure how well the translations preserved the original meaning.
+
+## Additional guidelines
+
+We also requested translators to mark loanwords that were adapted into Emakhuwa during the translation of each segment.

--- a/dataset_cards/flores/wuu_Hans.md
+++ b/dataset_cards/flores/wuu_Hans.md
@@ -1,0 +1,50 @@
+# Dataset card
+
+## Description
+
+FLORES+ dev set in Wu Chinese
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+```bibtex
+@inproceedings{wmt24-wu,
+    title="Machine Translation Evaluation Benchmark for {Wu}",
+    author="Hongjian Yu and Yiming Shi and Zherui Zhou and Christopher Haberland",
+    booktitle = "Proceedings of the Ninth Conference on Machine Translation",
+    month = nov,
+    year = "2024",
+    address = "Miami, USA",
+    publisher = "Association for Computational Linguistics"
+}
+```
+
+## Language codes
+
+* ISO 639-3: wuu
+* ISO 15924: Hans
+* Glottocode: suhu1238
+
+## Additional language information
+
+The target Wu variety is the Chongming dialect. The Chongming dialect (or more broadly the Shadi dialect) is a Wu dialect within the Su-Hu-Jia fraction, spoken in Chongming, Haimen and Qidong districts as well as in some areas of Zhangjiagang. Although Chongming belongs to the Manucipality of Shanghai, the dialect is distinctive from the urban variety on many aspects and is known for preserving many rare characteristics of Middle Chinese. Aside from the Shanghai dialect, the Chongming dialect is also similar to other Su-Hu-Jia dialects such as the Suzhou dialect.
+
+A list of language reference goes here:
+* 赵元任 (Yuen Ren Chao), 现代吴语的研究 (1956)
+* 钱乃荣, 当代吴语研究 (1992)
+* 闵家骥 et al., 简明吴方言词典 (1986)
+* 钱乃荣, 上海话大词典 (2008)
+* Wu Wikipedia [https://wuu.wikipedia.org/wiki/]
+* Wu Chinese Forum [https://wu-chinese.com/bbs/]
+* Online dictionaries for Wu Chinese [http://wu-chinese.com/minidict/index.php, https://www.wugniu.com/dict]
+
+## Workflow
+
+The FLORES+ Wu dataset is directly translated from English into Wu Chinese. Data were equally distributed and translated by 2 translators, both native speakers of the Chongming dialect, and have earned or are pursuing a university degree in English. Both translators grew up in Chongming; one went to Putuo, Shanghai for high school and college, and the other went to Fengxian, Shanghai for college. They mainly speak Wu at home but also to peers on occasion. They are in touch with the Shanghai urban dialect as well as other local varieties. All translated data were checked by another independent Wu speaker.
+
+## Additional guidelines
+
+The translators mainly used 简明吴方言词典 and then 上海话大词典 if they were unable to recall the orthogonal Hanzi that represent the utterances. Both dictionaries are based on the Shanghainese dialect. When the two dictionaries diverged in orthographies, 简明吴方言词典 was put in priority. When there was phonetic distinctions between the Chongming and Shanghai dialect and the original character was indeterminable, we made sure that the selected Hanzi has aligned pronunciation.

--- a/dataset_cards/flores/yue_Hant.md
+++ b/dataset_cards/flores/yue_Hant.md
@@ -1,0 +1,32 @@
+# Dataset card
+
+## Description
+
+FLORES+ in Hong Kong Cantonese
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+```bibtex
+@article{nllb-22,
+    title = {No Language Left Behind: Scaling Human-Centered Machine Translation},
+    author = {{NLLB Team} and Costa-jussà, Marta R. and Cross, James and Çelebi, Onur and Elbayad, Maha and Heafield, Kenneth and Heffernan, Kevin and Kalbassi, Elahe and Lam, Janice and Licht, Daniel and Maillard, Jean and Sun, Anna and Wang, Skyler and Wenzek, Guillaume and Youngblood, Al and Akula, Bapi and Barrault, Loic and Mejia-Gonzalez, Gabriel and Hansanti, Prangthip and Hoffman, John and Jarrett, Semarley and Sadagopan, Kaushik Ram and Rowe, Dirk and Spruit, Shannon and Tran, Chau and Andrews, Pierre and Ayan, Necip Fazil and Bhosale, Shruti and Edunov, Sergey and Fan, Angela and Gao, Cynthia and Goswami, Vedanuj and Guzmán, Francisco and Koehn, Philipp and Mourachko, Alexandre and Ropers, Christophe and Saleem, Safiyyah and Schwenk, Holger and Wang, Jeff},
+    year = {2022},
+    eprint = {arXiv:1902.01382},
+}
+```
+
+## Language codes
+
+* ISO 639-3: yue
+* ISO 15924: Hant
+* Glottocode: xian1255
+
+## Additional language information
+
+## Workflow
+
+This data was released as part of the FLORES-200 dataset. Due to the domain and register, it was found to be mostly in Mandarin. Following feedback, it was retranslated to better match Hong Kong Cantonese. Please refer to the paper for further information.

--- a/dataset_cards/flores/zgh_Tfng.md
+++ b/dataset_cards/flores/zgh_Tfng.md
@@ -1,0 +1,34 @@
+# Dataset card
+
+## Description
+
+FLORES+ in Standard Moroccan Tamazight
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+```bibtex
+@article{nllb-22,
+    title = {No Language Left Behind: Scaling Human-Centered Machine Translation},
+    author = {{NLLB Team} and Costa-jussà, Marta R. and Cross, James and Çelebi, Onur and Elbayad, Maha and Heafield, Kenneth and Heffernan, Kevin and Kalbassi, Elahe and Lam, Janice and Licht, Daniel and Maillard, Jean and Sun, Anna and Wang, Skyler and Wenzek, Guillaume and Youngblood, Al and Akula, Bapi and Barrault, Loic and Mejia-Gonzalez, Gabriel and Hansanti, Prangthip and Hoffman, John and Jarrett, Semarley and Sadagopan, Kaushik Ram and Rowe, Dirk and Spruit, Shannon and Tran, Chau and Andrews, Pierre and Ayan, Necip Fazil and Bhosale, Shruti and Edunov, Sergey and Fan, Angela and Gao, Cynthia and Goswami, Vedanuj and Guzmán, Francisco and Koehn, Philipp and Mourachko, Alexandre and Ropers, Christophe and Saleem, Safiyyah and Schwenk, Holger and Wang, Jeff},
+    year = {2022},
+    eprint = {arXiv:1902.01382},
+}
+```
+
+## Language codes
+
+* ISO 639-3: zgh
+* ISO 15924: Tfng
+* Glottocode: stan1324
+
+## Additional language information
+
+Reference dictionary: IRCAM’s [Dictionnaire Général de la Langue Amazighe Informatisé](https://tal.ircam.ma/dglai/lexieam.php).
+
+## Workflow
+
+This data was released as part of the FLORES-200 dataset, where it was incorrectly labeled `tzm_Tfng`. It was relabeled as `zgh_Tfng` after community feedback and additional quality assessment. Please refer to the paper for further information.

--- a/dataset_cards/seed/ary_Arab.md
+++ b/dataset_cards/seed/ary_Arab.md
@@ -1,0 +1,38 @@
+# Dataset card
+
+## Description
+
+Seed data in Moroccan Arabic
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+```bibtex
+@inproceedings{seed-23,
+    title = {Small Data, Big Impact: Leveraging Minimal Data for Effective Machine Translation},
+    author = {Maillard, Jean and Gao, Cynthia and Kalbassi, Elahe and Sadagopan, Kaushik Ram and Goswami, Vedanuj and Koehn, Philipp and Fan, Angela and Guzmán, Francisco},
+    booktitle = {Proceedings of the 61st Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)},
+    year = {2023},
+    address = {Toronto, Canada},
+    publisher = {Association for Computational Linguistics},
+    pages = {2740--2756},
+    url = {https://aclanthology.org/2023.acl-long.154},
+}
+```
+
+## Language codes
+
+* ISO 639-3: ary
+* ISO 15924: Arab
+* Glottocode: moro1292
+
+## Additional language information
+
+## Workflow
+
+An initial version of this data was was released as part of the NLLB-Seed dataset. It was retranslated after community feedback and additional quality assessment revealed the original data was too close to Modern Standard Arabic. Please refer to the paper for further information.
+
+## Additional guidelines

--- a/dataset_cards/seed/ben_Beng.md
+++ b/dataset_cards/seed/ben_Beng.md
@@ -1,0 +1,39 @@
+# Dataset card
+
+## Description
+
+Open source Seed dataset in Bangla/Bengali (Dhaka Bangla)
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+```bibtex
+@inproceedings{wmt24-seed-bangla,
+    title="The {Bangla/Bengali} Seed Dataset Submission to the {WMT24} Open Language Data Initiative Shared Task",
+    author="Firoz Ahmed and Nitin Venkateswaran and Sarah Moeller",
+    booktitle = "Proceedings of the Ninth Conference on Machine Translation",
+    month = nov,
+    year = "2024",
+    address = "Miami, USA",
+    publisher = "Association for Computational Linguistics"
+}
+```
+
+## Language codes
+
+* ISO 639-3: ben
+* ISO 15924: Beng
+* Glottocode: beng1280
+
+## Additional language information
+
+The data is in the Dhaka dialect of Bangla/Bengali
+
+Reference grammar: David, Anne Boye (2015), Descriptive Grammar of Bangla, De Gruyter Mouton, ISBN 9781614512295
+
+## Workflow
+
+Data was translated from the English sentences of the Seed dataset maintained by the Open Language Data Initiative. All 6,193 English sentences were translated into Bangla by a single native speaker of the language who is highly proficient in English (at C2 level of the European Language framework) and has experience with professional translation as well as a university degree in Linguistics from the United States.

--- a/dataset_cards/seed/ita_Latn.md
+++ b/dataset_cards/seed/ita_Latn.md
@@ -1,0 +1,50 @@
+# Dataset card
+
+## Description
+
+Seed data in Italian
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+The dataset is described in the following paper:
+```bibtex
+@inproceedings{wmt24-seed-italian,
+    title="A high-quality Seed dataset for {Italian} machine translation",
+    author="Edoardo Ferrante",
+    booktitle = "Proceedings of the Ninth Conference on Machine Translation",
+    month = nov,
+    year = "2024",
+    address = "Miami, USA",
+    publisher = "Association for Computational Linguistics"
+}
+```
+
+It is based on the original work of:
+```bibtex
+@inproceedings{zenamt24,
+    title = {{I}talian-{L}igurian Machine Translation in Its Cultural Context},
+    author = {Haberland, Christopher R. and Maillard, Jean and Lusito, Stefano},
+    booktitle = {Proceedings of the 3rd Annual Meeting of the Special Interest Group on Under-resourced Languages @ {LREC}-{COLING} 2024},
+    year = {2024},
+    url = {https://aclanthology.org/2024.sigul-1.21},
+    pages = {168--176},
+}
+```
+
+## Language codes
+
+* ISO 639-3: ita
+* ISO 15924: Latn
+* Glottocode: ital1282
+
+## Additional language information
+
+The data is in standard Italian, as spoken in the Republic of Italy. Further information on the history of the language is available in V. Coletti, _Storia dell'italiano letterario_, Einaudi, 2022. Spellcheckers for this language are available natively on all major word processing software packages and via [Hunspell](https://hunspell.github.io).
+
+## Workflow
+
+An initial version of this data, machine translated from English and partially post-edited, was released by Haberland et al. (see Attribution section). The data was subsequently reviewed in its entirety by two native speakers of Italian and further post-edited to ensure high quality. Please refer to the paper for further information.

--- a/dataset_cards/seed/lij_Latn.md
+++ b/dataset_cards/seed/lij_Latn.md
@@ -1,0 +1,46 @@
+# Dataset card
+
+## Description
+
+Seed data in Ligurian
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+```bibtex
+@inproceedings{seed-23,
+    title = {Small Data, Big Impact: Leveraging Minimal Data for Effective Machine Translation},
+    author = {Maillard, Jean and Gao, Cynthia and Kalbassi, Elahe and Sadagopan, Kaushik Ram and Goswami, Vedanuj and Koehn, Philipp and Fan, Angela and Guzmán, Francisco},
+    booktitle = {Proceedings of the 61st Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)},
+    year = {2023},
+    address = {Toronto, Canada},
+    publisher = {Association for Computational Linguistics},
+    pages = {2740--2756},
+    url = {https://aclanthology.org/2023.acl-long.154},
+}
+```
+
+## Language codes
+
+* ISO 639-3: lij
+* ISO 15924: Latn
+* Glottocode: geno1240
+
+## Additional language information
+
+The data is in the Genoese dialect, using traditional spelling as codified in the following reference dictionaries:
+* S. Lusito (2022) Dizionario italiano-genovese, Programma, ISBN 9788866438205.
+* The Council for Ligurian Linguistic Heritage’s [online Italian-Genoese dictionary](https://conseggio-ligure.org/en/dictionary/deize/).
+* E. Autelli, S. Lusito, C. Konecny, F. Toso (2018-2021) [GEPHRAS](https://romanistik-gephras.uibk.ac.at/).
+
+Reference grammar:
+* F. Toso (1997) Grammatica del genovese: varietà urbana e di koinè, Le Mani, ISBN 9788880120728.
+
+## Workflow
+
+This data was released as part of the NLLB-Seed dataset. It has undergone minor spelling and syntactic fixes following community feedback and additional quality assessment. Please refer to the paper for further information.
+
+## Additional guidelines

--- a/dataset_cards/seed/spa_Latn.md
+++ b/dataset_cards/seed/spa_Latn.md
@@ -1,0 +1,42 @@
+# Dataset card
+
+## Description
+
+Seed data in Spanish (Latin American).
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+```bibtex
+@inproceedings{wmt24-seed-spanish,
+    title="Spanish Corpus and Provenance with Computer-Aided Translation for the {WMT24} {OLDI} Shared Task",
+    author="Jose Cols",
+    booktitle = "Proceedings of the Ninth Conference on Machine Translation",
+    month = nov,
+    year = "2024",
+    address = "Miami, USA",
+    publisher = "Association for Computational Linguistics"
+}
+```
+
+## Language codes
+
+* ISO 639-3: spa
+* ISO 15924: Latn
+* Glottocode: amer1254
+
+## Additional language information
+
+* Reference dictionary: [Diccionario de americanismos](https://www.asale.org/damer/).
+* Reference grammar: [Nueva gramática de la lengua española](https://www.rae.es/gram%C3%A1tica/).
+
+## Workflow
+
+Data was translated from English by ten professional translators, all native speakers of the target language and proficient in English. 100% of the data was reviewed by a team of three translators.
+
+## Additional guidelines
+
+* Numeral formatting: [Diccionario panhispánico de dudas](https://www.rae.es/dpd/n%C3%BAmeros).

--- a/dataset_cards/seed/zgh_Tfng.md
+++ b/dataset_cards/seed/zgh_Tfng.md
@@ -1,0 +1,40 @@
+# Dataset card
+
+## Description
+
+Seed data in Standard Moroccan Tamazight
+
+## License
+
+CC-BY-SA-4.0
+
+## Attribution
+
+```bibtex
+@inproceedings{seed-23,
+    title = {Small Data, Big Impact: Leveraging Minimal Data for Effective Machine Translation},
+    author = {Maillard, Jean and Gao, Cynthia and Kalbassi, Elahe and Sadagopan, Kaushik Ram and Goswami, Vedanuj and Koehn, Philipp and Fan, Angela and Guzmán, Francisco},
+    booktitle = {Proceedings of the 61st Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)},
+    year = {2023},
+    address = {Toronto, Canada},
+    publisher = {Association for Computational Linguistics},
+    pages = {2740--2756},
+    url = {https://aclanthology.org/2023.acl-long.154},
+}
+```
+
+## Language codes
+
+* ISO 639-3: zgh
+* ISO 15924: Tfng
+* Glottocode: stan1324
+
+## Additional language information
+
+Reference dictionary: IRCAM’s [Dictionnaire Général de la Langue Amazighe Informatisé](https://tal.ircam.ma/dglai/lexieam.php).
+
+## Workflow
+
+This data was released as part of the NLLB-Seed dataset, where it was incorrectly labeled `tzm_Tfng`. It was relabeled as `zgh_Tfng` after community feedback and additional quality assessment. Please refer to the paper for further information.
+
+## Additional guidelines

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Jinja2==3.1.5
 markupsafe==2
 pyyaml==6
+mistune~=3.0.2

--- a/templates/dataset_card.html
+++ b/templates/dataset_card.html
@@ -1,0 +1,12 @@
+{% extends "index.html" %}
+
+{% block title %}Dataset card for {{ lang.display_name }} {% endblock %}
+
+{% block content %}
+    {% if orig_url %}
+    <div>The contents of this card can be edited <a href="{{ orig_url }}">in the source repository</a>.</div>
+    {% endif %}
+    <div>
+        {{ card_content | safe }}
+    </div>
+{% endblock %}

--- a/templates/languages.html
+++ b/templates/languages.html
@@ -16,7 +16,7 @@
 
 <table class="c l3 l4">
     <thead>
-        <tr><th>Code</th><th>Script</th><th>Glottocode</th><th>Language</th><th><a href="https://huggingface.co/datasets/openlanguagedata/flores_plus">FLORES+</a></th><th><a href="https://huggingface.co/datasets/openlanguagedata/oldi_seed">OLDI-Seed</a></th></tr>
+        <tr><th>Code</th><th>Script</th><th>Glottocode</th><th>Language</th><th><a href="https://huggingface.co/datasets/openlanguagedata/flores_plus">FLORES+</a></th><th><a href="https://huggingface.co/datasets/openlanguagedata/oldi_seed">OLDI-Seed</a></th><th>Data cards</th></tr>
     </thead>
     <tbody>
         {% for lang in languages -%}
@@ -42,6 +42,11 @@
                 {%- elif lang.datasets.seed == "partial" -%}
                 <img src="/partial.png" class="i" alt="partially available" title="partially available">
                 {%- endif -%}
+            </td>
+            <td>
+                {%- if lang.flores_card -%}<a href="{{ lang.flores_card }}">FLORES+</a>{%- endif -%}
+                {%- if lang.flores_card and lang.seed_card -%}, {%- endif -%}
+                {%- if lang.seed_card -%}<a href="{{ lang.seed_card }}">Seed</a>{%- endif -%}
             </td>
         </tr>
         {%- endfor %}


### PR DESCRIPTION
In this PR, I add the dataset cards directly into the oldi.org website, to make them more visible and discoverable.

How it is done:

- [x] Copy-paste all dataset cards into this repo (instead of copy-pasting manually, we could probably clone the repo from HF, but this does not seem more convenient, and would require a login for each build).
- [x] Compile each dataset card into an html page.
- [x] Add links to those pages in the list of languages (https://add-data-cards.oldi-org.pages.dev/languages)