### PR TITLE
Remove mentions of monolingual data

### DIFF
--- a/templates/guidelines.html
+++ b/templates/guidelines.html
@@ -13,24 +13,23 @@
 
 <ul class="checklist">
     <li><input type="checkbox"> Decide on your <a href="#contribution-type">type of contribution</a>.</li>
-    <li><input type="checkbox"> Email the organisers at <a href="mailto:info@oldi.org">info@oldi.org</a> to discuss your proposed contribution.</li>
+    <li><input type="checkbox"> Contact the organisers, via <a href="mailto:info@oldi.org">email</a> or <a href="https://discord.gg/jJmrw3E77u">Discord</a>, to discuss your proposed contribution.</li>
     <li><input type="checkbox"> Identify the right <a href="#language-codes">language code</a> for your contribution.</li>
     <li><input type="checkbox"> Fill out a <a href="#dataset-card">dataset card</a> and ensure all people participating in data collection or annotation have acknowledged its contents.</li>
-    <li><input type="checkbox"> For translation projects, ensure all translators have acknowledged the <a href="#translation-guidelines">translation guidelines</a>. For monolingual projects, ensure all contributors have acknowledged the <a href="#monolingual-guidelines">monolingual contribution guidelines</a>.</li>
+    <li><input type="checkbox"> Ensure all translators have acknowledged the <a href="#translation-guidelines">translation guidelines</a></li>
     <li><input type="checkbox"> Deliver the data and dataset card by submitting a pull request to the <a href="https://huggingface.co/openlanguagedata#datasets">appropriate repository</a> and accepting the <a href="https://developercertificate.org/">DCO</a>.</li>
 </ul>
 
 <h2 id="contribution-type">Types of contribution</h2>
 
-<p>There are three main types of contributions:</p>
+<p>There are two main types of contributions:</p>
 
 <ol>
     <li><strong>Fixes to existing data:</strong> in case of incorrect or incomplete exisiting translations.</li>
     <li><strong>Completely new translations:</strong> typically involves starting from the original English data and having it translated by qualified, native speakers of the target language (see <a href="#translation-guidelines">translation guidelines</a>).</li>
-    <li><strong>Other contributions:</strong> for example, new monolingual datasets (see <a href="#monolingual-guidelines">monolingual contribution guidelines</a>).</li>
 </ol>
 
-<p>In each case, before starting work please make sure to email the organisers at <a href="mailto:info@oldi.org">info@oldi.org</a>. This ensures nobody else is already working on the same task and allows the community to better coordinate work.</p>
+<p>In each case, before starting work please make sure to email the organisers at <a href="mailto:info@oldi.org">info@oldi.org</a> or get in touch on <a href="https://discord.gg/jJmrw3E77u">Discord</a>. This ensures nobody else is already working on the same task and allows the community to better coordinate work.</p>
 
 <h2 id="language-codes">Language codes</h2>
 
@@ -156,89 +155,5 @@
         </ol>
     </li>
 </ol>
-
-<h2 id="monolingual-guidelines">Monolingual contribution guidelines</h2>
-
-<p>All contributors must acknowledge the following guidelines.</p>
-
-<h3>Important note</h3>
-
-<p>The goal of this effort is the collection of high-quality textual monolingual data, for the purposes of training language identification systems, language models and other related tools. <strong><img class="inline" src="/caution.svg" alt="[Caution]"> Synthetic data is not allowed</strong>. Examples of disallowed synthetic data include machine-translated content, LLM output, and text generated from templates.</p>
-
-<h3>General guidelines</h3>
-
-<ol>
-    <li>All contributed data must be human-generated. Surface changes that are mechanical in nature (such as certain types of transliteration) may be performed with the aid of automated systems, provided this is clearly documented.</li>
-    <li>Clearly identify the provenance of the data. In many cases, this may be done by providing a URL or a bibliographic reference.</li>
-    <li>Ensure the data is in the claimed language and free of issues such as encoding problems. If at all possible, this should be done by having one or more native speakers manually check a sufficiently large representative sample of the whole dataset.</li>
-</ol>
-
-<h3>Data format</h3>
-
-<ol>
-    <li>Data must be in plain text format.</li>
-    <li>Minimal markup in <a href="https://spec.commonmark.org/">Markdown format</a> may be used where applicable. Markup should be limited to italics, bold, ordered and unordered lists, inline code spans, block quotes, ATX headings (<code>#</code>, <code>##</code>). Strikethrough (<code>~~</code>), footnotes (<code>[^1]</code>) and mathematics formatting (<code>$</code> and <code>$$</code>) with <a href="https://docs.gitlab.com/ee/user/markdown.html">GitLab/GFM compatible syntax</a> may also be used.</li>
-    <li>
-        Where possible, we strongly encourage contributions of document-level data, rather than sentence-level data. Retaining the context that comes with full documents enables the development of more sophisticated models.
-        <ol>
-            <li>For document-level data, there must be one document per file. Paragraphs must be separated by two subsequent newlines.</li>
-            <li>For sentence-level data, sentences must be separated by single newlines.</li>
-        </ol>
-    </li>
-    <li>
-        A standardised set of metadata must be added in the form of a YAML front matter. The front matter must be placed at the top of each file, preceding the textual content, and must be delimited by <code>---</code>.
-        <ol>
-            <li>Analogously to a <a href="#dataset-card">dataset card</a>, the language of the data must be marked using the <code>iso_639_3</code>, <code>iso_15924</code> and <code>glottocode</code> fields under the top-level <code>language</code> key. Should this structure be too restrictive for a given dataset, e.g. for code-switched text, please reach out to the organisers at <a href="mailto:info@oldi.org">info@oldi.org</a>.</li>
-            <li>The source of the data must be specified in the <code>source</code> field. This may take the form of a URL, a bibliographic reference, or free-form text.</li>
-            <li>The license, in the form of an <a href="https://spdx.org/licenses/">SPDX license identifier</a>, must be specified in the <code>license</code> field.</li>
-            <li>The date of submission of the data must be specified in <code>YYYY-MM-DD</code> format in the <code>submission_date</code> field.</li>
-            <li>Document-level data must be marked as <code>document: true</code>, whereas sentence-level data must be marked as <code>document: false</code>.</li>
-            <li>Files that use Markdown syntax must set <code>markdown: true</code>.</li>
-        </ol>
-    </li>
-</ol>
-
-<p>The following is an example of well-formed document-level data.</p>
-
-<div class="code box"><strong>---</strong>
-<strong>language</strong>:
-&nbsp;&nbsp;<strong>iso_639_3</strong>: eng
-&nbsp;&nbsp;<strong>iso_15924</strong>: Latn
-&nbsp;&nbsp;<strong>glottocode</strong>: stan1293
-<strong>source</strong>: https://en.wikipedia.org/wiki/Generative_grammar
-<strong>license</strong>: CC-BY-SA-4.0
-<strong>submission_date</strong>: 2024-05-05
-<strong>document</strong>: true
-<strong>markdown</strong>: true
-<strong>---</strong>
-<strong># Generative grammar</strong>&nbsp;
-
-<strong>**Generative grammar**</strong> is a theoretical approach in linguistics that regards grammar as a domain-specific system of rules that generates all and only the grammatical sentences of a given language. In light of poverty of the stimulus arguments, grammar is regarded as being partly innate, the innate portion of the system being referred to as universal grammar. The generative approach has focused on the study of syntax while addressing other aspects of language including semantics, morphology, phonology, and psycholinguistics.
-
-<strong>## Frameworks</strong>
-
-There are a number of different approaches to generative grammar. Common to all is the effort to come up with a set of rules or principles that formally defines every one of the members of the set of well-formed expressions of a natural language. The term <em>_generative grammar_</em> has been associated with at least the following schools of linguistics:
-
-...
-</div>
-
-<p>The following is an example of well-formed sentence-level data.</p>
-
-<div class="code box"><strong>---</strong>
-<strong>language</strong>:
-&nbsp;&nbsp;<strong>iso_639_3</strong>: xxx
-&nbsp;&nbsp;<strong>iso_15924</strong>: Xxxx
-&nbsp;&nbsp;<strong>glottocode</strong>: xxxx1234
-<strong>source</strong>: Example sentences extracted from: A. Bloggs. 1904. Notes on Language X. Journal of Language Studies. 24-40.
-<strong>license</strong>: CC-0
-<strong>submission_date</strong>: 2024-05-05
-<strong>document</strong>: false
-<strong>markdown</strong>: false
-<strong>---</strong>
-This is a sentence.
-This is another sentence.
-This is a third sentence.
-...
-</div>
 
 {% endblock %}


### PR DESCRIPTION
Remove mentions of monolingual data to ensure we don't get contributions that don't fit with our new direction. I'd like to do a few more PRs after this one to:
1. List other datasets we can accept contributions/corrections for [if we're all OK with that] such as WMT24++, NTrex, FLORES, SMOL. Our policy could be to first attempt to send PRs to the original repos, and if that fails we can host the new version ourselves.
2. Have some guidelines for communities on where to start contirbuting. FLORES+ devtest as very first step, WMT24++/Bouquet for more advanced performance tracking.